### PR TITLE
feat: add movie lookup by TMDB and IMDB ID methods

### DIFF
--- a/examples/lookup-movie-by-id.ts
+++ b/examples/lookup-movie-by-id.ts
@@ -32,15 +32,49 @@ async function demonstrateLookupById() {
   console.log(`   Found: ${movieUnifiedImdb.data?.title} (${movieUnifiedImdb.data?.year})`);
   console.log(`   Runtime: ${movieUnifiedImdb.data?.runtime} minutes\n`);
 
-  // Example 5: Error handling
-  console.log('5️⃣  Testing error handling with invalid format...');
+  // Example 5: Error handling - Invalid provider
+  console.log('5️⃣  Testing error handling...\n');
+
+  console.log('   Testing invalid provider:');
   try {
     await radarr.lookupMovieById('invalid:123');
   } catch (error) {
-    console.log(`   ✅ Error caught: ${error instanceof Error ? error.message : String(error)}\n`);
+    console.log(`   ✅ ${error instanceof Error ? error.message : String(error)}\n`);
   }
 
-  console.log('✨ All lookups completed successfully!');
+  console.log('   Testing invalid TMDB ID (non-numeric):');
+  try {
+    await radarr.lookupMovieById('tmdb:abc');
+  } catch (error) {
+    console.log(`   ✅ ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+
+  console.log('   Testing invalid TMDB ID (zero):');
+  try {
+    await radarr.lookupMovieById('tmdb:0');
+  } catch (error) {
+    console.log(`   ✅ ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+
+  console.log('   Testing invalid IMDB ID (missing tt prefix):');
+  try {
+    await radarr.lookupMovieById('imdb:0175142');
+  } catch (error) {
+    console.log(`   ✅ ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+
+  console.log('   Testing missing colon:');
+  try {
+    await radarr.lookupMovieById('tmdb123');
+  } catch (error) {
+    console.log(`   ✅ ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+
+  console.log('   Testing case-insensitive provider (TMDB):');
+  const movieUppercase = await radarr.lookupMovieById('TMDB:4247');
+  console.log(`   ✅ Successfully handled: ${movieUppercase.data?.title}\n`);
+
+  console.log('✨ All lookups and validations completed successfully!');
 }
 
 demonstrateLookupById().catch(console.error);

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -124,6 +124,7 @@ export class RadarrClient {
    * Search for a movie by external ID (TMDB or IMDB)
    * @param id - Format: 'tmdb:123' or 'imdb:tt0175142'
    * @returns Movie details from the specified provider
+   * @throws Error if the ID format is invalid or values don't meet requirements
    * @example
    * ```typescript
    * // Lookup by TMDB ID
@@ -134,16 +135,54 @@ export class RadarrClient {
    * ```
    */
   async lookupMovieById(id: string) {
-    const [provider, value] = id.split(':');
+    // Verify the ID contains exactly one colon
+    const parts = id.split(':');
+    if (parts.length !== 2) {
+      throw new Error(
+        'Invalid ID format. Must contain exactly one colon. Use "tmdb:123" or "imdb:tt0175142"'
+      );
+    }
 
+    const [providerRaw, value] = parts;
+
+    // Verify both provider and value are non-empty
+    if (!providerRaw || !value) {
+      throw new Error(
+        'Invalid ID format. Both provider and value must be non-empty. Use "tmdb:123" or "imdb:tt0175142"'
+      );
+    }
+
+    // Normalize provider to lowercase and validate
+    const provider = providerRaw.toLowerCase();
+    if (provider !== 'tmdb' && provider !== 'imdb') {
+      throw new Error(`Invalid provider "${providerRaw}". Must be either "tmdb" or "imdb"`);
+    }
+
+    // Validate and process based on provider
     if (provider === 'tmdb') {
-      return RadarrApi.getApiV3MovieLookupTmdb({ query: { tmdbId: Number(value) } });
-    }
-    if (provider === 'imdb') {
-      return RadarrApi.getApiV3MovieLookupImdb({ query: { imdbId: value } });
+      // Parse and validate TMDB ID
+      const tmdbId = Number.parseInt(value, 10);
+
+      if (Number.isNaN(tmdbId)) {
+        throw new Error(`Invalid TMDB ID "${value}". Must be a numeric value`);
+      }
+
+      if (!Number.isInteger(tmdbId) || tmdbId <= 0) {
+        throw new Error(`Invalid TMDB ID "${value}". Must be a positive integer`);
+      }
+
+      return RadarrApi.getApiV3MovieLookupTmdb({ query: { tmdbId } });
     }
 
-    throw new Error('Invalid ID format. Use "tmdb:123" or "imdb:tt0175142"');
+    // Validate IMDB ID format (must be tt followed by digits)
+    const imdbPattern = /^tt\d+$/;
+    if (!imdbPattern.test(value)) {
+      throw new Error(
+        `Invalid IMDB ID "${value}". Must match pattern "tt" followed by digits (e.g., "tt0175142")`
+      );
+    }
+
+    return RadarrApi.getApiV3MovieLookupImdb({ query: { imdbId: value } });
   }
 
   // Command APIs


### PR DESCRIPTION
- Add lookupMovieByTmdbId() method for direct TMDB ID lookups
- Add lookupMovieByImdbId() method for direct IMDB ID lookups
- Add lookupMovieById() unified method supporting 'tmdb:123' and 'imdb:tt123' formats
- Add comprehensive example demonstrating all lookup methods
- Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added movie lookup by TMDB ID, IMDB ID, and a unified provider-string format (e.g., tmdb:123 or imdb:tt123).
  * Example script demonstrating lookups, case-insensitive provider handling, and usage flows.

* **Bug Fixes**
  * Improved error handling and clearer messages for malformed or unsupported ID formats.

* **Documentation**
  * Included a usage example showcasing lookup results and common error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->