### PR TITLE
chore: pin bun and @types/bun versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
           
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
           
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
           
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "tsarr",
@@ -11,7 +10,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "@semantic-release/npm": "^13.1.4",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.9",
         "semantic-release": "^25.0.3",
         "typedoc": "^0.28.17",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.4",
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.9",
     "semantic-release": "^25.0.3",
     "typedoc": "^0.28.17",
     "typescript": "^5.9.3"

--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,14 @@
     {
       "groupName": "TypeScript",
       "matchPackageNames": [
-        "typescript",
-        "@types/bun"
+        "typescript"
+      ]
+    },
+    {
+      "groupName": "Bun",
+      "matchPackageNames": [
+        "@types/bun",
+        "oven-sh/setup-bun"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Pin `bun-version` in all CI workflows from `latest` to `1.3.9` so builds are reproducible and Renovate can track updates
- Pin `@types/bun` in package.json from `latest` to `^1.3.9` so Renovate can version-manage it
- Add a `Bun` group in `renovate.json` to keep `@types/bun` and `oven-sh/setup-bun` updates together

## Test plan
- [ ] CI passes with pinned Bun 1.3.9
- [ ] Renovate picks up the new tracking config on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Pinned Bun runtime version to 1.3.9 across development workflows, continuous integration pipelines, and type definitions to ensure consistency across the development environment.
* Updated dependency grouping configuration to better manage automated updates for Bun-related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->