### PR TITLE
fix: polish refresh output and search limits

### DIFF
--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { LidarrClient } from '../../clients/lidarr.js';
 import { promptConfirm, promptSelect } from '../prompt.js';
 import type { ResourceDef } from './service.js';
-import { buildServiceCommand } from './service.js';
+import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS } from './service.js';
 
 const resources: ResourceDef[] = [
   {
@@ -107,12 +107,14 @@ const resources: ResourceDef[] = [
         name: 'refresh',
         description: 'Refresh artist metadata',
         args: [{ name: 'id', description: 'Artist ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: LidarrClient, a) => c.runCommand({ name: 'RefreshArtist', artistId: a.id } as any),
       },
       {
         name: 'manual-search',
         description: 'Trigger a manual search for releases',
         args: [{ name: 'id', description: 'Artist ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: LidarrClient, a) => c.runCommand({ name: 'ArtistSearch', artistId: a.id } as any),
       },
       {

--- a/src/cli/commands/prowlarr.ts
+++ b/src/cli/commands/prowlarr.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { ProwlarrClient } from '../../clients/prowlarr.js';
 import { promptIfMissing } from '../prompt.js';
 import type { ResourceDef } from './service.js';
-import { buildServiceCommand } from './service.js';
+import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS } from './service.js';
 
 const resources: ResourceDef[] = [
   {
@@ -135,6 +135,7 @@ const resources: ResourceDef[] = [
       {
         name: 'sync',
         description: 'Trigger app indexer sync',
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: ProwlarrClient) => c.runCommand({ name: 'AppIndexerMapSync' } as any),
       },
     ],

--- a/src/cli/commands/radarr.ts
+++ b/src/cli/commands/radarr.ts
@@ -2,9 +2,9 @@ import { readFileSync } from 'node:fs';
 import { RadarrClient } from '../../clients/radarr.js';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt.js';
 import type { ResourceDef } from './service.js';
-import { buildServiceCommand } from './service.js';
+import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS, limitResults } from './service.js';
 
-const resources: ResourceDef[] = [
+export const resources: ResourceDef[] = [
   {
     name: 'movie',
     description: 'Manage movies',
@@ -25,10 +25,16 @@ const resources: ResourceDef[] = [
       {
         name: 'search',
         description: 'Search for movies on TMDB',
-        args: [{ name: 'term', description: 'Search term', required: true }],
+        args: [
+          { name: 'term', description: 'Search term', required: true },
+          { name: 'limit', description: 'Max results to show', type: 'number' },
+        ],
         columns: ['tmdbId', 'title', 'year', 'overview'],
         idField: 'tmdbId',
-        run: (c: RadarrClient, a) => c.searchMovies(a.term),
+        run: async (c: RadarrClient, a) => {
+          const results = unwrapData<any[]>(await c.searchMovies(a.term));
+          return limitResults(results, a.limit);
+        },
       },
       {
         name: 'add',
@@ -149,6 +155,7 @@ const resources: ResourceDef[] = [
         name: 'refresh',
         description: 'Refresh movie metadata',
         args: [{ name: 'id', description: 'Movie ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: RadarrClient, a) =>
           c.runCommand({ name: 'RefreshMovie', movieIds: [a.id] } as any),
       },
@@ -156,6 +163,7 @@ const resources: ResourceDef[] = [
         name: 'manual-search',
         description: 'Trigger a manual search for releases',
         args: [{ name: 'id', description: 'Movie ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: RadarrClient, a) =>
           c.runCommand({ name: 'MoviesSearch', movieIds: [a.id] } as any),
       },

--- a/src/cli/commands/readarr.ts
+++ b/src/cli/commands/readarr.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { ReadarrClient } from '../../clients/readarr.js';
 import { promptConfirm, promptSelect } from '../prompt.js';
 import type { ResourceDef } from './service.js';
-import { buildServiceCommand } from './service.js';
+import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS } from './service.js';
 
 const resources: ResourceDef[] = [
   {
@@ -107,6 +107,7 @@ const resources: ResourceDef[] = [
         name: 'refresh',
         description: 'Refresh author metadata',
         args: [{ name: 'id', description: 'Author ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: ReadarrClient, a) =>
           c.runCommand({ name: 'RefreshAuthor', authorId: a.id } as any),
       },
@@ -114,6 +115,7 @@ const resources: ResourceDef[] = [
         name: 'manual-search',
         description: 'Trigger a manual search for releases',
         args: [{ name: 'id', description: 'Author ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: ReadarrClient, a) => c.runCommand({ name: 'AuthorSearch', authorId: a.id } as any),
       },
       {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -29,6 +29,16 @@ export interface ResourceDef {
   actions: ActionDef[];
 }
 
+export const COMMAND_OUTPUT_COLUMNS = ['id', 'name', 'status', 'result', 'queued', 'trigger'];
+
+export function limitResults<T>(results: T[], limit: number | undefined): T[] {
+  if (limit === undefined) return results;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error('--limit must be a positive integer.');
+  }
+  return results.slice(0, limit);
+}
+
 export function buildServiceCommand(
   serviceName: string,
   description: string,

--- a/src/cli/commands/sonarr.ts
+++ b/src/cli/commands/sonarr.ts
@@ -2,9 +2,9 @@ import { readFileSync } from 'node:fs';
 import { SonarrClient } from '../../clients/sonarr.js';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt.js';
 import type { ResourceDef } from './service.js';
-import { buildServiceCommand } from './service.js';
+import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS, limitResults } from './service.js';
 
-const resources: ResourceDef[] = [
+export const resources: ResourceDef[] = [
   {
     name: 'series',
     description: 'Manage TV series',
@@ -50,9 +50,15 @@ const resources: ResourceDef[] = [
       {
         name: 'search',
         description: 'Search for TV series',
-        args: [{ name: 'term', description: 'Search term', required: true }],
+        args: [
+          { name: 'term', description: 'Search term', required: true },
+          { name: 'limit', description: 'Max results to show', type: 'number' },
+        ],
         columns: ['tvdbId', 'title', 'year', 'overview'],
-        run: (c: SonarrClient, a) => c.searchSeries(a.term),
+        run: async (c: SonarrClient, a) => {
+          const results = unwrapData<any[]>(await c.searchSeries(a.term));
+          return limitResults(results, a.limit);
+        },
       },
       {
         name: 'add',
@@ -169,12 +175,14 @@ const resources: ResourceDef[] = [
         name: 'refresh',
         description: 'Refresh series metadata',
         args: [{ name: 'id', description: 'Series ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: SonarrClient, a) => c.runCommand({ name: 'RefreshSeries', seriesId: a.id } as any),
       },
       {
         name: 'manual-search',
         description: 'Trigger a manual search for releases',
         args: [{ name: 'id', description: 'Series ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: SonarrClient, a) => c.runCommand({ name: 'SeriesSearch', seriesId: a.id } as any),
       },
       {
@@ -228,6 +236,7 @@ const resources: ResourceDef[] = [
         name: 'search',
         description: 'Trigger a search for an episode',
         args: [{ name: 'id', description: 'Episode ID', required: true, type: 'number' }],
+        columns: COMMAND_OUTPUT_COLUMNS,
         run: (c: SonarrClient, a) =>
           c.runCommand({ name: 'EpisodeSearch', episodeIds: [a.id] } as any),
       },

--- a/tests/cli-command-defs.test.ts
+++ b/tests/cli-command-defs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import { resources as radarrResources } from '../src/cli/commands/radarr.js';
+import { COMMAND_OUTPUT_COLUMNS, limitResults } from '../src/cli/commands/service.js';
+import { resources as sonarrResources } from '../src/cli/commands/sonarr.js';
+
+function getAction(
+  resources: Array<{
+    name: string;
+    actions: Array<{ name: string; args?: Array<{ name: string }>; columns?: string[] }>;
+  }>,
+  resourceName: string,
+  actionName: string
+) {
+  const resource = resources.find(item => item.name === resourceName);
+  expect(resource).toBeDefined();
+
+  const action = resource?.actions.find(item => item.name === actionName);
+  expect(action).toBeDefined();
+
+  return action!;
+}
+
+describe('CLI command definitions', () => {
+  it('adds a limit arg to Radarr and Sonarr lookup searches', () => {
+    const radarrSearch = getAction(radarrResources, 'movie', 'search');
+    const sonarrSearch = getAction(sonarrResources, 'series', 'search');
+
+    expect(radarrSearch.args?.some(arg => arg.name === 'limit')).toBe(true);
+    expect(sonarrSearch.args?.some(arg => arg.name === 'limit')).toBe(true);
+  });
+
+  it('uses shared command columns for refresh table output', () => {
+    const radarrRefresh = getAction(radarrResources, 'movie', 'refresh');
+    const sonarrRefresh = getAction(sonarrResources, 'series', 'refresh');
+
+    expect(radarrRefresh.columns).toEqual(COMMAND_OUTPUT_COLUMNS);
+    expect(sonarrRefresh.columns).toEqual(COMMAND_OUTPUT_COLUMNS);
+  });
+});
+
+describe('limitResults', () => {
+  it('caps array results to the provided limit', () => {
+    expect(limitResults([1, 2, 3], 2)).toEqual([1, 2]);
+  });
+
+  it('returns all results when no limit is provided', () => {
+    expect(limitResults([1, 2, 3], undefined)).toEqual([1, 2, 3]);
+  });
+
+  it('rejects non-positive limits', () => {
+    expect(() => limitResults([1, 2, 3], 0)).toThrow('--limit must be a positive integer.');
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -117,6 +117,30 @@ describe('CLI smoke tests', () => {
     }
   });
 
+  it('should expose the search limit flag for Radarr and Sonarr lookup commands', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
+
+    try {
+      const commands = [
+        ['run', 'src/cli/index.ts', 'radarr', 'movie', 'search', '--help'],
+        ['run', 'src/cli/index.ts', 'sonarr', 'series', 'search', '--help'],
+      ];
+
+      for (const command of commands) {
+        const result = spawnSync('bun', command, {
+          cwd: process.cwd(),
+          env: buildCliEnv(tempHome),
+          encoding: 'utf-8',
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('--limit');
+      }
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it('should expose Sonarr queue and history list subcommands', () => {
     const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
 


### PR DESCRIPTION
## Summary
- add a shared command table layout for refresh/manual search style command responses
- add a CLI-side `--limit` option to Radarr movie and Sonarr series lookup commands
- cover the new flags and command output wiring with CLI tests

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--limit` flag to search commands (Radarr, Sonarr) to control maximum results displayed
  * Standardized output formatting across services for consistent command display

* **Tests**
  * Added test coverage for limit functionality and output column consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->