### PR TITLE
fix: Bazarr CLI uses wrong API base path

### DIFF
--- a/src/clients/bazarr.ts
+++ b/src/clients/bazarr.ts
@@ -4,8 +4,9 @@ import { client as bazarrClient } from '../generated/bazarr/client.gen.js';
 import * as BazarrApi from '../generated/bazarr/index.js';
 
 function getBazarrApiBaseUrl(baseUrl: string): string {
-  const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
-  return normalizedBaseUrl.endsWith('/api') ? normalizedBaseUrl : `${normalizedBaseUrl}/api`;
+  // Generated SDK paths already include /api/ prefix, so strip it from the base URL
+  // to avoid double-prefixing (e.g. /api/api/system/status)
+  return baseUrl.replace(/\/+$/, '').replace(/\/api$/, '');
 }
 
 function getBazarrHeaders(config: ReturnType<typeof createServarrClient>) {

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -424,18 +424,18 @@ describe('Client Unit Tests', () => {
       expect(client).toBeInstanceOf(BazarrClient);
     });
 
-    it('should configure the raw client with the /api prefix', () => {
+    it('should configure the raw client without /api prefix (SDK paths include it)', () => {
       new BazarrClient(validConfig);
-      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767/api');
+      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767');
     });
 
-    it('should not duplicate the /api prefix when already present', () => {
+    it('should strip /api suffix when user includes it in base URL', () => {
       new BazarrClient({
         baseUrl: 'http://localhost:6767/api',
         apiKey: 'valid-api-key',
       });
 
-      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767/api');
+      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767');
     });
 
     it('should configure generated auth for Bazarr requests', () => {


### PR DESCRIPTION
## Summary
- Fixed double-prefixed URLs (`/api/api/system/status`) by stripping `/api` from base URL since generated SDK paths already include `/api/` prefix
- Corrects doctor check which was failing with "Unexpected response payload"
- Response unwrapping for Bazarr's `{"data": {...}}` format already handled by CLI

## Root Cause
The `getBazarrApiBaseUrl()` function appended `/api` to user-provided base URLs, but the generated Bazarr SDK paths already start with `/api/`. This caused requests to incorrect paths that returned HTML instead of JSON.

## Testing
- All 115 unit tests pass
- Linter clean
- Updated tests to verify `/api` suffix is stripped when user includes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bazarr API client base URL normalization to prevent duplicate API path prefixes and ensure correct endpoint routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->