### PR TITLE
fix: broken repo-hosted Nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,18 @@ jobs:
             Please review the changes and merge if everything looks correct.
           branch: chore/update-api-clients
           delete-branch: true
+
+  nix-flake:
+    runs-on: arc-tsarr
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build Nix flake
+        run: |
+          docker run --rm \
+            -v "$PWD/packaging/nix:/work" \
+            -w /work \
+            nixos/nix:2.24.14 \
+            sh -lc 'nix build .#default --extra-experimental-features "nix-command flakes"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,20 @@ jobs:
           name: chocolatey-package-${{ github.sha }}
           path: /tmp/chocolatey-package.tar.gz
 
+      - name: Commit generated Nix flake
+        if: steps.semantic.outputs.released == 'true'
+        run: |
+          workspace="${GITHUB_WORKSPACE:-$PWD}"
+          tmpdir="$(mktemp -d)"
+          cp "$workspace/packaging/nix/flake.nix" "$tmpdir/flake.nix"
+          git checkout main
+          cp "$tmpdir/flake.nix" packaging/nix/flake.nix
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add packaging/nix/flake.nix
+          git commit -m "chore: update nix flake for v${{ steps.semantic.outputs.version }} [skip ci]" || true
+          git push origin HEAD:main
+
   docker:
     runs-on: arc-tsarr
     needs: release

--- a/README.md
+++ b/README.md
@@ -109,7 +109,15 @@ yay -S tsarr-bin
 
 ### Nix
 
-Nix packaging is prepared under [`packaging/nix/flake.nix`](./packaging/nix/flake.nix), but shared distribution still requires a maintainer submission. See [docs/distribution.md](./docs/distribution.md) for the setup and submission flow.
+Install the repo flake directly:
+
+```bash
+nix profile install github:robbeverhelst/tsarr?dir=packaging/nix
+# or run it without installing
+nix run github:robbeverhelst/tsarr?dir=packaging/nix -- doctor
+```
+
+The committed flake under [`packaging/nix/flake.nix`](./packaging/nix/flake.nix) tracks the latest published release. Shared `nixpkgs` distribution still requires a maintainer submission. See [docs/distribution.md](./docs/distribution.md) for the full distribution flow.
 
 ## CLI
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -39,7 +39,7 @@ The Linux release job uses the official 1Password GitHub Action. The Windows Cho
 
 ## Generate the channel manifests
 
-The files tracked under [`packaging/`](../packaging) are templates. Before you submit anything to AUR, Scoop, Chocolatey, or Nix, generate the versioned manifests with the current release number and binary checksums.
+The files under [`packaging/`](../packaging) are generated from the release binaries. Before you submit anything to AUR, Scoop, Chocolatey, or Nix, generate the versioned manifests with the current release number and binary checksums.
 
 Use the same sequence as the release workflow on the release commit:
 
@@ -61,7 +61,7 @@ bun build src/cli/index.ts --compile --target=bun-windows-x64 --outfile release-
 bun run update-packaging <released-version>
 ```
 
-After that, the files in [`packaging/`](../packaging) will contain the actual version and SHA256 values you should submit.
+After that, the files in [`packaging/`](../packaging) will contain the actual version and SHA256 values you should submit. The release workflow also commits the generated Nix flake back to `main` so the repo-hosted flake stays installable.
 
 ## Channel checklist
 
@@ -74,7 +74,7 @@ After that, the files in [`packaging/`](../packaging) will contain the actual ve
 | Scoop | `scoop bucket add tsarr https://github.com/robbeverhelst/scoop-tsarr` then `scoop install tsarr` | GitHub bucket repo or upstream Scoop PR | Yes, if you use the repo-owned bucket |
 | Chocolatey | `choco install tsarr` | Chocolatey account + API key | Yes, after the `Tsarr/tsarr-release-ci` `chocolatey-api-key` field is populated and `OP_SERVICE_ACCOUNT_TOKEN` is available |
 | AUR | `yay -S tsarr-bin` | AUR account + SSH key | Yes, using `Tsarr/tsarr-aur-ed25519-v2`, once `OP_SERVICE_ACCOUNT_TOKEN` is available |
-| Nix | Pending `nixpkgs` submission or a published repo flake | None for the repo flake, GitHub + nixpkgs PR for nixpkgs inclusion | Repo flake template: yes. `nixpkgs`: no |
+| Nix | `nix profile install github:robbeverhelst/tsarr?dir=packaging/nix` | None for the repo flake, GitHub + nixpkgs PR for nixpkgs inclusion | Repo flake: yes. `nixpkgs`: no |
 
 ## What to do next
 
@@ -163,8 +163,10 @@ For the repo-owned bucket, CI keeps the manifest current automatically.
 
 There are two different Nix paths here:
 
-- [`packaging/nix/flake.nix`](../packaging/nix/flake.nix) is a starting point for a generated repo-local flake.
+- [`packaging/nix/flake.nix`](../packaging/nix/flake.nix) is the repo-hosted flake users can install directly.
 - `nixpkgs` inclusion is a separate upstream contribution and is not automated by this repo.
+
+The release workflow regenerates the repo flake from the published release binaries and commits it back to `main`, so the checked-in flake stays aligned with the latest release.
 
 If you want shared `nixpkgs` availability, use the package definition here as a starting point and open a PR to `NixOS/nixpkgs`. Expect that to be the slowest review path of the distribution channels.
 
@@ -177,5 +179,6 @@ If you want shared `nixpkgs` availability, use the package definition here as a 
 - [`packaging/chocolatey/tools/chocolateyInstall.ps1`](../packaging/chocolatey/tools/chocolateyInstall.ps1)
 - [`packaging/scoop/tsarr.json`](../packaging/scoop/tsarr.json)
 - [`packaging/nix/flake.nix`](../packaging/nix/flake.nix)
+- [`packaging/nix/flake.lock`](../packaging/nix/flake.lock)
 - [`scripts/update-packaging.ts`](../scripts/update-packaging.ts)
 - [`.github/workflows/release.yml`](../.github/workflows/release.yml)

--- a/packaging/nix/flake.lock
+++ b/packaging/nix/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -10,23 +10,23 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        version = "VERSION_PLACEHOLDER";
+        version = "2.4.6";
         src = {
           "x86_64-linux" = pkgs.fetchurl {
             url = "https://github.com/robbeverhelst/tsarr/releases/download/v${version}/tsarr-linux-x64";
-            sha256 = "";
+            sha256 = "sha256-Gq1LzvHtWjuAi+My1TGU9+Yh2P47/R4stSYCq4fciTg=";
           };
           "aarch64-linux" = pkgs.fetchurl {
             url = "https://github.com/robbeverhelst/tsarr/releases/download/v${version}/tsarr-linux-arm64";
-            sha256 = "";
+            sha256 = "sha256-vA8/8pvvTdFdOZ3MVD3iidIztGXmTxSphw+VwgrL3qU=";
           };
           "x86_64-darwin" = pkgs.fetchurl {
             url = "https://github.com/robbeverhelst/tsarr/releases/download/v${version}/tsarr-darwin-x64";
-            sha256 = "";
+            sha256 = "sha256-eQ4XjrpaDHOfNgugUsXFMhV4HTT8jV51W6p5VI5i7ME=";
           };
           "aarch64-darwin" = pkgs.fetchurl {
             url = "https://github.com/robbeverhelst/tsarr/releases/download/v${version}/tsarr-darwin-arm64";
-            sha256 = "";
+            sha256 = "sha256-w8QunMptBRu/1SlIYIfYq72RuKLvptusjvP5a9JCBeM=";
           };
         };
       in

--- a/scripts/update-packaging.ts
+++ b/scripts/update-packaging.ts
@@ -43,7 +43,7 @@ console.log('Updated Homebrew formula');
 // Update Nix flake
 const nixPath = join(root, 'packaging', 'nix', 'flake.nix');
 let nix = readFileSync(nixPath, 'utf-8');
-nix = nix.replace(/version = "VERSION_PLACEHOLDER"/, `version = "${version}"`);
+nix = nix.replace(/version = "[^"]+"/, `version = "${version}"`);
 // Update sha256 values for each platform
 const nixSha256Replacements = [
   { url: 'tsarr-linux-x64', hash: hashes['linux-x64'] },
@@ -52,7 +52,7 @@ const nixSha256Replacements = [
   { url: 'tsarr-darwin-arm64', hash: hashes['darwin-arm64'] },
 ];
 for (const { url, hash } of nixSha256Replacements) {
-  const regex = new RegExp(`(${url}";\\s*sha256 = )"";`, 'g');
+  const regex = new RegExp(`(${url}";\\s*sha256 = )"[^"]*";`, 'g');
   const sriHash = Buffer.from(hash, 'hex').toString('base64');
   nix = nix.replace(regex, `$1"sha256-${sriHash}";`);
 }


### PR DESCRIPTION
This makes the checked-in Nix flake installable by pinning it to the current release, adding a flake lock, and updating the docs to use the repo-hosted install path. It also updates scripts/update-packaging.ts so future releases can overwrite an existing flake, and adds CI coverage with a Dockerized nix build. The release workflow now commits the regenerated Nix flake back to main after releases so the repo copy stays current. Verified locally with a Dockerized nix build and a temp update-packaging run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nix flake now available for direct installation from the repository
  * Added CI validation for Nix flake builds

* **Documentation**
  * Updated installation instructions with explicit Nix flake commands
  * Clarified that the repository flake is the authoritative Nix distribution

* **Chores**
  * Automated Nix flake generation and synchronization during releases
  * Enhanced packaging script flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->