### PR TITLE
Remove Renovate schedule delays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     "config:recommended",
     ":semanticCommitTypeAll(chore)"
   ],
-  "schedule": [
-    "before 6am on monday"
-  ],
   "timezone": "Europe/Brussels",
   "assignees": [
     "robbeverhelst"
@@ -42,9 +39,6 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 6am on monday"
-    ]
+    "enabled": true
   }
 }


### PR DESCRIPTION
This removes the global Renovate schedule so dependency updates can open PRs as soon as Renovate detects them. It also removes the separate lock file maintenance schedule to avoid those updates sitting in an awaiting-schedule state. No other workspace changes are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency maintenance configuration to remove time-based scheduling restrictions, allowing updates to be processed without timing constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->