### PR TITLE
fix: relax sdk type test timeout

### DIFF
--- a/tests/sdk-types.test.ts
+++ b/tests/sdk-types.test.ts
@@ -101,5 +101,6 @@ describe('SDK type packaging', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  }, 60000);
+    // This test shells out to TypeScript twice and can exceed 60s on shared CI runners.
+  }, 120000);
 });


### PR DESCRIPTION
## Summary
- raise the SDK packaging test timeout from 60s to 120s
- keep the same assertions while reducing slow-runner flakiness in GitHub Actions

## Verification
- bun test tests/sdk-types.test.ts
- bun run generate && bun run generate:types && bun run typecheck && bun run lint && bun test && bun run build:js && bun run build:cli && bun run build:types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout for SDK type packaging test to improve reliability on slower systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->