### PR TITLE
Add ClawHub-published tsarr skill

### DIFF
--- a/.github/workflows/clawhub-skill.yml
+++ b/.github/workflows/clawhub-skill.yml
@@ -51,7 +51,6 @@ jobs:
       contents: read
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json
 
     steps:
       - name: Require 1Password service account token

--- a/.github/workflows/clawhub-skill.yml
+++ b/.github/workflows/clawhub-skill.yml
@@ -1,0 +1,108 @@
+name: ClawHub Skill
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/tsarr/**'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/tsarr/**'
+  workflow_dispatch:
+
+concurrency:
+  group: clawhub-skill-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: arc-tsarr
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.0'
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Validate ClawHub skill sync plan
+        run: >
+          clawhub sync
+          --root skills
+          --all
+          --dry-run
+          --no-input
+          --changelog "CI validation"
+          --tags "latest,tsarr,servarr,radarr,sonarr,lidarr,readarr,prowlarr,bazarr,home-media,self-hosted"
+
+  publish:
+    runs-on: arc-tsarr
+    needs: validate
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub-config.json
+
+    steps:
+      - name: Require 1Password service account token
+        run: |
+          if [ -z "${OP_SERVICE_ACCOUNT_TOKEN}" ]; then
+            echo "Missing required secret: OP_SERVICE_ACCOUNT_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure 1Password
+        uses: 1password/load-secrets-action/configure@v4
+        with:
+          service-account-token: ${{ env.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Load ClawHub token from 1Password
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          CLAWHUB_TOKEN: op://Tsarr/clawhub/api-token
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.0'
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Require injected ClawHub token
+        run: |
+          if [ -z "${CLAWHUB_TOKEN}" ]; then
+            echo "Missing required 1Password item: op://Tsarr/clawhub/api-token" >&2
+            exit 1
+          fi
+
+      - name: Authenticate to ClawHub
+        run: clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
+
+      - name: Confirm authenticated account
+        run: clawhub whoami
+
+      - name: Publish or update skills on ClawHub
+        run: >
+          clawhub sync
+          --root skills
+          --all
+          --no-input
+          --bump patch
+          --changelog "Sync tsarr skill from ${GITHUB_SHA}"
+          --tags "latest,tsarr,servarr,radarr,sonarr,lidarr,readarr,prowlarr,bazarr,home-media,self-hosted"

--- a/.github/workflows/clawhub-skill.yml
+++ b/.github/workflows/clawhub-skill.yml
@@ -30,18 +30,21 @@ jobs:
         with:
           node-version: '24.14.0'
 
-      - name: Install ClawHub CLI
-        run: npm install -g clawhub
-
-      - name: Validate ClawHub skill sync plan
-        run: >
-          clawhub sync
-          --root skills
-          --all
-          --dry-run
-          --no-input
-          --changelog "CI validation"
-          --tags "latest,tsarr,servarr,radarr,sonarr,lidarr,readarr,prowlarr,bazarr,home-media,self-hosted"
+      - name: Validate skill bundle structure
+        run: |
+          test -f skills/tsarr/SKILL.md
+          test -f skills/tsarr/references/setup.md
+          test -f skills/tsarr/references/common-workflows.md
+          test -f skills/tsarr/references/service-cheatsheet.md
+          grep -q '^name: tsarr$' skills/tsarr/SKILL.md
+          grep -q '^description:' skills/tsarr/SKILL.md
+          grep -q '^metadata:$' skills/tsarr/SKILL.md
+          grep -q 'openclaw:' skills/tsarr/SKILL.md
+          grep -q 'bins:' skills/tsarr/SKILL.md
+          grep -q 'package: tsarr' skills/tsarr/SKILL.md
+          grep -q 'references/setup.md' skills/tsarr/SKILL.md
+          grep -q 'references/common-workflows.md' skills/tsarr/SKILL.md
+          grep -q 'references/service-cheatsheet.md' skills/tsarr/SKILL.md
 
   publish:
     runs-on: arc-tsarr

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ bunx tsarr doctor
 brew install robbeverhelst/tsarr/tsarr
 ```
 
+### OpenClaw / ClawHub
+
+Install the published OpenClaw skill to manage your Servarr stack through TsArr:
+
+```bash
+openclaw clawhub install tsarr
+# or with the registry CLI
+clawhub install tsarr
+```
+
 ### Pre-built Binaries
 
 Download standalone binaries from [GitHub Releases](https://github.com/robbeverhelst/tsarr/releases) — no runtime needed:

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,10 +19,11 @@ That means Homebrew, Scoop, AUR, and Chocolatey can all run from CI once their o
 
 ## 1Password-backed CI secrets
 
-This repo is set up to read release channel secrets from 1Password when `OP_SERVICE_ACCOUNT_TOKEN` is available to GitHub Actions.
+This repo reads release-channel credentials from 1Password when `OP_SERVICE_ACCOUNT_TOKEN` is available to GitHub Actions.
 
 Current 1Password items:
 
+- `op://Tsarr/clawhub/api-token`
 - `op://Tsarr/tsarr-release-ci/dist-repo-token`
 - `op://Tsarr/tsarr-release-ci/ci/chocolatey-api-key`
 - `op://Tsarr/tsarr-aur-ed25519-v2/private key`
@@ -30,6 +31,7 @@ Current 1Password items:
 
 Current secret references:
 
+- `op://Tsarr/clawhub/api-token`
 - `op://Tsarr/tsarr-release-ci/dist-repo-token`
 - `op://Tsarr/tsarr-release-ci/ci/chocolatey-api-key`
 - `op://Tsarr/tsarr-aur-ed25519-v2/private key`
@@ -70,6 +72,7 @@ After that, the files in [`packaging/`](../packaging) will contain the actual ve
 | npm | `npm install -g tsarr` | npm account + `NPM_TOKEN` secret | Yes |
 | GitHub Releases | Download binary asset | GitHub repo | Yes |
 | Docker | `docker run --rm ghcr.io/robbeverhelst/tsarr doctor` | GitHub repo / GHCR | Yes |
+| ClawHub | `openclaw clawhub install tsarr` or `clawhub install tsarr` | ClawHub account + token stored at `op://Tsarr/clawhub/api-token` | Yes |
 | Homebrew | `brew install robbeverhelst/tsarr/tsarr` | GitHub tap repo | Yes |
 | Scoop | `scoop bucket add tsarr https://github.com/robbeverhelst/scoop-tsarr` then `scoop install tsarr` | GitHub bucket repo or upstream Scoop PR | Yes, if you use the repo-owned bucket |
 | Chocolatey | `choco install tsarr` | Chocolatey account + API key | Yes, after the `Tsarr/tsarr-release-ci` `chocolatey-api-key` field is populated and `OP_SERVICE_ACCOUNT_TOKEN` is available |
@@ -80,20 +83,40 @@ After that, the files in [`packaging/`](../packaging) will contain the actual ve
 
 With the GitHub repos and 1Password items in place, the remaining practical order is:
 
-1. Make sure the `Tsarr/tsarr-aur-ed25519-v2` public key is the one registered in your AUR account profile.
-2. Add your Chocolatey API key to `op://Tsarr/tsarr-release-ci/ci/chocolatey-api-key`.
-3. Make sure `OP_SERVICE_ACCOUNT_TOKEN` is available to this repo in GitHub Actions.
-4. Let the next release publish Homebrew, Scoop, AUR, and Chocolatey automatically.
-5. Open a `nixpkgs` PR if you want `tsarr` available from the shared Nix package collection.
+1. Add the ClawHub API token to `op://Tsarr/clawhub/api-token`.
+2. Make sure the `Tsarr/tsarr-aur-ed25519-v2` public key is the one registered in your AUR account profile.
+3. Add your Chocolatey API key to `op://Tsarr/tsarr-release-ci/ci/chocolatey-api-key`.
+4. Make sure `OP_SERVICE_ACCOUNT_TOKEN` is available to this repo in GitHub Actions.
+5. Let the next release and skill sync publish ClawHub, Homebrew, Scoop, AUR, and Chocolatey automatically.
+6. Open a `nixpkgs` PR if you want `tsarr` available from the shared Nix package collection.
 
 ## Manual inputs still required
 
 These are the only pieces CI cannot create by itself:
 
+- ClawHub API token: add it to `op://Tsarr/clawhub/api-token` for non-interactive `clawhub login --token`.
 - AUR account settings: make sure the `Tsarr/tsarr-aur-ed25519-v2` public key is registered in your AUR profile.
 - Chocolatey API key: add it to the `tsarr-release-ci` item in 1Password.
 - GitHub Actions service-account access: `OP_SERVICE_ACCOUNT_TOKEN` must be available to this repo.
 - `nixpkgs` merge: upstream review is manual even if you script PR creation.
+
+## ClawHub
+
+The OpenClaw skill lives in [`skills/tsarr/`](../skills/tsarr/).
+
+Automation behavior:
+
+- PRs that touch the skill run a `clawhub sync --dry-run` validation workflow.
+- Pushes to `main` that touch the skill run `clawhub sync --all --bump patch` to publish or update the `tsarr` skill on ClawHub.
+- The workflow requires `OP_SERVICE_ACCOUNT_TOKEN`, loads `op://Tsarr/clawhub/api-token` through 1Password, and logs in non-interactively with `clawhub login --token`.
+
+End-user install commands:
+
+```bash
+openclaw clawhub install tsarr
+# or
+clawhub install tsarr
+```
 
 ## Homebrew
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -106,7 +106,7 @@ The OpenClaw skill lives in [`skills/tsarr/`](../skills/tsarr/).
 
 Automation behavior:
 
-- PRs that touch the skill run a `clawhub sync --dry-run` validation workflow.
+- PRs that touch the skill run a local structure/frontmatter validation workflow for `skills/tsarr/`.
 - Pushes to `main` that touch the skill run `clawhub sync --all --bump patch` to publish or update the `tsarr` skill on ClawHub.
 - The workflow requires `OP_SERVICE_ACCOUNT_TOKEN`, loads `op://Tsarr/clawhub/api-token` through 1Password, and logs in non-interactively with `clawhub login --token`.
 

--- a/skills/tsarr/SKILL.md
+++ b/skills/tsarr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: tsarr
+description: Manage home media services through TsArr from OpenClaw. Use for Radarr, Sonarr, Lidarr, Readarr, Prowlarr, and Bazarr tasks such as checking health, inspecting queues and history, browsing libraries, searching, adding, editing, deleting items, viewing profiles, tags, and root folders, and checking TsArr configuration.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - tsarr
+      config:
+        - .tsarr.json
+        - ~/.config/tsarr/config.json
+    install:
+      - kind: node
+        package: tsarr
+        bins:
+          - tsarr
+    homepage: https://github.com/robbeverhelst/tsarr
+    emoji: "🎬"
+---
+
+# TsArr
+
+Manage Servarr apps through the `tsarr` CLI.
+
+## Start
+
+- Verify the CLI is available with `tsarr --help`.
+- If setup or service health is unclear, read [references/setup.md](references/setup.md) and start with `tsarr doctor`.
+- Prefer `--json` when selecting IDs, extracting fields, or comparing results.
+
+## Safety
+
+- Inspect before mutating.
+- Fetch the current item before `edit` or `delete` when possible.
+- Avoid `--yes` on destructive commands unless the user explicitly wants non-interactive execution.
+- If the user says "Arr", "library", or "queue" without naming a service, clarify which service to use.
+
+## Routing
+
+- Read [references/setup.md](references/setup.md) for installation expectations, configuration, and connectivity checks.
+- Read [references/common-workflows.md](references/common-workflows.md) for health checks, library browsing, search, add, queue, history, refresh, and delete flows.
+- Read [references/service-cheatsheet.md](references/service-cheatsheet.md) to map a user request to the correct `service resource action` command.
+
+## Notes
+
+- Trust the command patterns in these references over stale prose elsewhere.
+- Keep responses operational: show the command you plan to run, summarize the result, and call out any destructive effect before you execute it.

--- a/skills/tsarr/references/common-workflows.md
+++ b/skills/tsarr/references/common-workflows.md
@@ -1,0 +1,164 @@
+# Common Workflows
+
+## Output modes
+
+Prefer:
+
+- `--json` for parsing and field selection
+- `--table` for human inspection in a terminal
+- `--plain` for TSV-style piping
+- `--quiet` when only IDs are needed
+- `--select=field1,field2` to reduce noisy JSON
+
+Examples:
+
+```bash
+tsarr radarr movie list --json --select=title,year,monitored
+tsarr sonarr series list --quiet
+```
+
+## Health and status
+
+Start here when the user wants to know whether the stack is healthy:
+
+```bash
+tsarr doctor
+tsarr radarr system status --json
+tsarr radarr system health --json
+tsarr sonarr system status --json
+tsarr prowlarr system health --json
+tsarr bazarr system status --json
+```
+
+## Browse libraries
+
+Use these for inspection before any write operation:
+
+```bash
+tsarr radarr movie list --json
+tsarr radarr movie get --id 123 --json
+
+tsarr sonarr series list --json
+tsarr sonarr series get --id 456 --json
+tsarr sonarr episode list --series-id 456 --json
+
+tsarr lidarr artist list --json
+tsarr lidarr album list --json
+
+tsarr readarr author list --json
+tsarr readarr book list --json
+
+tsarr bazarr series list --json
+tsarr bazarr movie list --json
+tsarr bazarr episode wanted --json
+```
+
+## Search and add
+
+Use search first. Let TsArr prompt for quality profile and root folder when needed.
+
+```bash
+tsarr radarr movie search --term "Interstellar" --limit 5 --json
+tsarr radarr movie add --term "Interstellar"
+
+tsarr sonarr series search --term "Breaking Bad" --limit 5 --json
+tsarr sonarr series add --term "Breaking Bad"
+
+tsarr lidarr artist search --term "Radiohead" --json
+tsarr lidarr artist add --term "Radiohead"
+
+tsarr readarr author search --term "Ursula Le Guin" --json
+tsarr readarr author add --term "Ursula Le Guin"
+```
+
+Use ID-based adds when the user already knows the external identifier:
+
+```bash
+tsarr radarr movie add --tmdb-id 157336
+tsarr sonarr series add --tvdb-id 81189
+```
+
+## Queue and history
+
+Use these to inspect stuck downloads, failed grabs, or recent activity:
+
+```bash
+tsarr radarr queue list --json
+tsarr radarr queue status --json
+tsarr radarr history list --json
+
+tsarr sonarr queue list --json
+tsarr sonarr history list --json
+
+tsarr lidarr queue list --json
+tsarr readarr queue list --json
+```
+
+## Metadata and helpers
+
+Use these when the user needs supporting IDs before an add or edit:
+
+```bash
+tsarr radarr profile list --json
+tsarr radarr rootfolder list --json
+tsarr radarr tag list --json
+
+tsarr sonarr profile list --json
+tsarr sonarr rootfolder list --json
+
+tsarr lidarr profile list --json
+tsarr readarr profile list --json
+
+tsarr prowlarr indexer list --json
+tsarr prowlarr app list --json
+tsarr prowlarr search run --term "ubuntu iso" --json
+```
+
+## Refresh and manual search
+
+Use these when the library exists but metadata or release search needs to be retriggered:
+
+```bash
+tsarr radarr movie refresh --id 123
+tsarr radarr movie manual-search --id 123
+
+tsarr sonarr series refresh --id 456
+tsarr sonarr series manual-search --id 456
+
+tsarr lidarr artist refresh --id 789
+tsarr readarr author refresh --id 321
+```
+
+## Delete safely
+
+Inspect first, then delete. Do not pass `--yes` unless the user explicitly wants automation.
+
+```bash
+tsarr radarr movie get --id 123 --json
+tsarr radarr movie delete --id 123
+
+tsarr sonarr series get --id 456 --json
+tsarr sonarr series delete --id 456
+
+tsarr lidarr artist get --id 789 --json
+tsarr lidarr artist delete --id 789
+
+tsarr readarr author get --id 321 --json
+tsarr readarr author delete --id 321
+```
+
+Use extra destructive flags only when the user clearly asks for them:
+
+```bash
+tsarr radarr movie delete --id 123 --delete-files
+tsarr sonarr series delete --id 456 --delete-files
+```
+
+## Configuration checks
+
+When a command fails unexpectedly, inspect TsArr’s merged configuration:
+
+```bash
+tsarr config show
+tsarr config get services.prowlarr.baseUrl
+```

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -1,0 +1,133 @@
+# Service Cheatsheet
+
+## Radarr
+
+Use for movies.
+
+```bash
+tsarr radarr movie list --json
+tsarr radarr movie get --id 123 --json
+tsarr radarr movie search --term "Interstellar" --limit 5 --json
+tsarr radarr movie add --term "Interstellar"
+tsarr radarr movie refresh --id 123
+tsarr radarr movie manual-search --id 123
+tsarr radarr queue list --json
+tsarr radarr history list --json
+```
+
+Useful helpers:
+
+```bash
+tsarr radarr profile list --json
+tsarr radarr rootfolder list --json
+tsarr radarr tag list --json
+tsarr radarr system health --json
+```
+
+## Sonarr
+
+Use for TV series and episodes.
+
+```bash
+tsarr sonarr series list --json
+tsarr sonarr series get --id 456 --json
+tsarr sonarr series search --term "Breaking Bad" --limit 5 --json
+tsarr sonarr series add --term "Breaking Bad"
+tsarr sonarr series refresh --id 456
+tsarr sonarr series manual-search --id 456
+tsarr sonarr episode list --series-id 456 --json
+tsarr sonarr episode search --id 999
+```
+
+Useful helpers:
+
+```bash
+tsarr sonarr queue list --json
+tsarr sonarr history list --json
+tsarr sonarr system health --json
+```
+
+## Lidarr
+
+Use for artists and albums.
+
+```bash
+tsarr lidarr artist list --json
+tsarr lidarr artist get --id 789 --json
+tsarr lidarr artist search --term "Radiohead" --json
+tsarr lidarr artist add --term "Radiohead"
+tsarr lidarr artist refresh --id 789
+tsarr lidarr album list --json
+tsarr lidarr album get --id 654 --json
+tsarr lidarr album search --term "OK Computer" --json
+```
+
+Useful helpers:
+
+```bash
+tsarr lidarr queue list --json
+tsarr lidarr history list --json
+tsarr lidarr system health --json
+```
+
+## Readarr
+
+Use for authors and books.
+
+```bash
+tsarr readarr author list --json
+tsarr readarr author get --id 321 --json
+tsarr readarr author search --term "Ursula Le Guin" --json
+tsarr readarr author add --term "Ursula Le Guin"
+tsarr readarr author refresh --id 321
+tsarr readarr book list --json
+tsarr readarr book get --id 654 --json
+tsarr readarr book search --term "The Left Hand of Darkness" --json
+```
+
+Useful helpers:
+
+```bash
+tsarr readarr queue list --json
+tsarr readarr history list --json
+tsarr readarr system health --json
+```
+
+## Prowlarr
+
+Use for indexers, connected apps, and cross-indexer search.
+
+```bash
+tsarr prowlarr indexer list --json
+tsarr prowlarr indexer get --id 12 --json
+tsarr prowlarr indexer test --json
+tsarr prowlarr search run --term "ubuntu iso" --json
+tsarr prowlarr app list --json
+tsarr prowlarr app sync
+tsarr prowlarr system health --json
+```
+
+Advanced Prowlarr add/edit flows use `--file` JSON input. Prefer read-only inspection unless the user explicitly wants to change indexers, applications, notifications, or download clients.
+
+## Bazarr
+
+Use for subtitle status and provider inspection.
+
+```bash
+tsarr bazarr series list --json
+tsarr bazarr movie list --json
+tsarr bazarr episode wanted --json
+tsarr bazarr provider list --json
+tsarr bazarr language list --json
+tsarr bazarr language profiles --json
+tsarr bazarr system status --json
+tsarr bazarr system health --json
+tsarr bazarr system badges --json
+```
+
+## Mutation rules
+
+- Run `get` or `list` first when a delete or edit is requested.
+- Use `--json` when extracting IDs or confirming the target.
+- Reserve `--yes` for explicit automation requests.
+- Expect some advanced add/edit commands to require JSON input files instead of simple flags.

--- a/skills/tsarr/references/setup.md
+++ b/skills/tsarr/references/setup.md
@@ -1,0 +1,75 @@
+# Setup
+
+## Verify the CLI
+
+- Check whether `tsarr` is installed with `tsarr --help`.
+- If the binary is missing, let OpenClaw satisfy the declared install dependency for `tsarr`.
+
+## Configure TsArr
+
+Use the interactive wizard first when the user has not configured their services yet:
+
+```bash
+tsarr config init
+```
+
+Inspect current configuration with:
+
+```bash
+tsarr config show
+tsarr config get services.radarr.baseUrl
+```
+
+Set values manually with:
+
+```bash
+tsarr config set services.radarr.baseUrl http://localhost:7878
+tsarr config set services.radarr.apiKey your-api-key
+tsarr config set services.radarr.baseUrl http://localhost:7878 --local
+```
+
+## Connectivity checks
+
+Start here when a user says setup is broken, credentials may be wrong, or a service may be offline:
+
+```bash
+tsarr doctor
+tsarr radarr system status --json
+tsarr sonarr system health --json
+```
+
+## Config precedence
+
+TsArr merges configuration in this order:
+
+1. Service-specific environment variables
+2. Local config at `.tsarr.json`
+3. Global config at `~/.config/tsarr/config.json`
+
+Use local config for project-specific stacks. Use global config for the user’s default home setup.
+
+## Environment variable pattern
+
+TsArr also supports service-specific environment variables with these patterns:
+
+- `TSARR_{SERVICE}_URL`
+- `TSARR_{SERVICE}_API_KEY`
+- `TSARR_{SERVICE}_TIMEOUT`
+
+Replace `{SERVICE}` with `RADARR`, `SONARR`, `LIDARR`, `READARR`, `PROWLARR`, or `BAZARR`.
+
+## Default ports
+
+- Radarr: `7878`
+- Sonarr: `8989`
+- Lidarr: `8686`
+- Readarr: `8787`
+- Prowlarr: `9696`
+- Bazarr: `6767`
+
+## Practical workflow
+
+1. Run `tsarr doctor`.
+2. If a service is missing, inspect `tsarr config show`.
+3. If a single value looks wrong, use `tsarr config get ...` or `tsarr config set ...`.
+4. Retry the failing service command with `--json` so output is easy to inspect.


### PR DESCRIPTION
Adds a publishable OpenClaw/ClawHub skill at skills/tsarr for managing Radarr, Sonarr, Lidarr, Readarr, Prowlarr, and Bazarr through the tsarr CLI. Adds a dedicated GitHub Actions workflow that validates skill changes on PRs and publishes updates from main through ClawHub using the existing 1Password secret injection flow. Updates the README and distribution guide with the new install path, automation behavior, and required 1Password item for ClawHub publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClawHub skill distribution channel with automated CI/CD for dry-run validation on pull requests and publishing to main.
  * Tsarr skill now installable via `clawhub install tsarr` or `openclaw clawhub install tsarr`.

* **Documentation**
  * Added comprehensive tsarr skill documentation: setup guides, common workflows, service command references, and safety practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->