### PR TITLE
Add npm downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![npm](https://img.shields.io/npm/v/tsarr?style=flat-square)](https://www.npmjs.com/package/tsarr)
+[![npm downloads](https://img.shields.io/npm/dm/tsarr?style=flat-square)](https://www.npmjs.com/package/tsarr)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/robbeverhelst/Tsarr/workflows/CI/badge.svg)](https://github.com/robbeverhelst/Tsarr/actions)
 


### PR DESCRIPTION
## Summary
Add a Shields.io badge for monthly npm downloads to the README badge row.
Keep the existing flat-square badge style and link it to the Type-safe CLI for Servarr APIs (Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr) (tsarr v2.4.6)

USAGE tsarr radarr|sonarr|lidarr|readarr|prowlarr|bazarr|doctor|config|completions

COMMANDS

       radarr    Manage Radarr (Movies)                 
       sonarr    Manage Sonarr (TV Shows)               
       lidarr    Manage Lidarr (Music)                  
      readarr    Manage Readarr (Books)                 
     prowlarr    Manage Prowlarr (Indexers)             
       bazarr    Manage Bazarr (Subtitles)              
       doctor    Test all configured service connections
       config    Manage CLI configuration               
  completions    Generate shell completion scripts      

Use tsarr <command> --help for more information about a command. npm package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added npm downloads badge to the README for enhanced package visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->