### PR TITLE
fix(cli): fix Seerr paginated output, dry-run, and qbit UX (#161)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -111,7 +111,7 @@ export const doctor = defineCommand({
 
     formatOutput(results, {
       format,
-      columns: ['service', 'status', 'version', 'baseUrl', 'error'],
+      columns: ['service', 'status', 'configured', 'version', 'baseUrl', 'error'],
       idField: 'service',
       select: args.select,
     });

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -195,7 +195,8 @@ export function buildServiceCommand(
 
     // When a resource has exactly one action, make it the default so
     // e.g. `tsarr qbit status` works without requiring `tsarr qbit status show`
-    const singleAction = resource.actions.length === 1 ? actionCommands[resource.actions[0].name] : undefined;
+    const singleAction =
+      resource.actions.length === 1 ? actionCommands[resource.actions[0].name] : undefined;
 
     subCommands[resource.name] = defineCommand({
       meta: {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -125,7 +125,7 @@ export function buildServiceCommand(
               process.argv.includes('--dry-run')
             );
 
-            if (dryRun && isWriteAction(action.name)) {
+            if (dryRun) {
               formatOutput(
                 buildDryRunPreview(format, serviceName, resource.name, action.name, resolvedArgs),
                 {
@@ -173,9 +173,11 @@ export function buildServiceCommand(
             ) {
               result = result.data;
             }
-            // Unwrap paginated responses (e.g. { records: [...], page, totalRecords })
+            // Unwrap paginated responses (e.g. { records: [...] } or { results: [...] })
             if (result?.records !== undefined && Array.isArray(result.records)) {
               result = result.records;
+            } else if (result?.results !== undefined && Array.isArray(result.results)) {
+              result = result.results;
             }
             formatOutput(result, {
               format,
@@ -191,12 +193,17 @@ export function buildServiceCommand(
       });
     }
 
+    // When a resource has exactly one action, make it the default so
+    // e.g. `tsarr qbit status` works without requiring `tsarr qbit status show`
+    const singleAction = resource.actions.length === 1 ? actionCommands[resource.actions[0].name] : undefined;
+
     subCommands[resource.name] = defineCommand({
       meta: {
         name: resource.name,
         description: resource.description,
       },
       subCommands: actionCommands,
+      ...(singleAction ? { run: singleAction.run } : {}),
     });
   }
 
@@ -218,23 +225,6 @@ function coerceBooleanArg(value: unknown): boolean {
   }
 
   return Boolean(value);
-}
-
-function isWriteAction(actionName: string): boolean {
-  return [
-    'add',
-    'create',
-    'delete',
-    'edit',
-    'pause',
-    'resume',
-    'refresh',
-    'manual-search',
-    'grab',
-    'sync',
-    'test',
-    'search',
-  ].includes(actionName);
 }
 
 function buildDryRunPreview(

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -34,7 +34,12 @@ export function formatOutput(
 
   switch (options.format) {
     case 'json': {
-      const output = options.select ? selectFields(data, options.select) : data;
+      let output: unknown = data;
+      if (options.select) {
+        output = selectFields(data, options.select);
+      } else if (options.columns && Array.isArray(data)) {
+        output = selectFields(data, options.columns.join(','));
+      }
       console.log(JSON.stringify(output, null, 2));
       break;
     }

--- a/tests/cli-output.test.ts
+++ b/tests/cli-output.test.ts
@@ -41,6 +41,78 @@ describe('CLI output formatting', () => {
     expect(output).not.toContain('ORIGINAL LANGUAGE');
   });
 
+  it('select filters fields from an array of objects', () => {
+    formatOutput(
+      [
+        { id: 1, name: 'Alice', email: 'alice@example.com' },
+        { id: 2, name: 'Bob', email: 'bob@example.com' },
+      ],
+      { format: 'json', select: 'id,name' }
+    );
+
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+  });
+
+  it('quiet mode extracts id field from array items', () => {
+    formatOutput([{ id: 10 }, { id: 20 }, { id: 30 }], { format: 'quiet', idField: 'id' });
+
+    expect(logs).toEqual(['10', '20', '30']);
+  });
+
+  it('plain mode renders rows from array items', () => {
+    formatOutput(
+      [
+        { id: 1, status: 'ok' },
+        { id: 2, status: 'fail' },
+      ],
+      { format: 'plain', columns: ['id', 'status'] }
+    );
+
+    expect(logs[0]).toBe('id\tstatus');
+    expect(logs[1]).toBe('1\tok');
+    expect(logs[2]).toBe('2\tfail');
+  });
+
+  it('json mode applies columns to arrays by default', () => {
+    formatOutput(
+      [
+        { id: 1, name: 'Alice', email: 'alice@example.com', extra: 'data' },
+        { id: 2, name: 'Bob', email: 'bob@example.com', extra: 'more' },
+      ],
+      { format: 'json', columns: ['id', 'name'] }
+    );
+
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+  });
+
+  it('json mode does not apply columns to single objects', () => {
+    formatOutput(
+      { id: 1, name: 'Alice', email: 'alice@example.com' },
+      { format: 'json', columns: ['id', 'name'] }
+    );
+
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed).toEqual({ id: 1, name: 'Alice', email: 'alice@example.com' });
+  });
+
+  it('select overrides columns in json mode', () => {
+    formatOutput(
+      [{ id: 1, name: 'Alice', email: 'alice@example.com' }],
+      { format: 'json', columns: ['id', 'name'], select: 'email' }
+    );
+
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed).toEqual([{ email: 'alice@example.com' }]);
+  });
+
   it('uses a visible ellipsis when truncating table cells', () => {
     formatOutput([{ overview: 'x'.repeat(120) }], {
       format: 'table',

--- a/tests/cli-output.test.ts
+++ b/tests/cli-output.test.ts
@@ -104,10 +104,11 @@ describe('CLI output formatting', () => {
   });
 
   it('select overrides columns in json mode', () => {
-    formatOutput(
-      [{ id: 1, name: 'Alice', email: 'alice@example.com' }],
-      { format: 'json', columns: ['id', 'name'], select: 'email' }
-    );
+    formatOutput([{ id: 1, name: 'Alice', email: 'alice@example.com' }], {
+      format: 'json',
+      columns: ['id', 'name'],
+      select: 'email',
+    });
 
     const parsed = JSON.parse(logs.join('\n'));
     expect(parsed).toEqual([{ email: 'alice@example.com' }]);


### PR DESCRIPTION
## Summary

Fixes all bugs reported in #161:

- **Seerr paginated output broken**: `--select`, `--plain`, `--quiet` returned empty results for paginated Seerr endpoints (`requests list`, `search query`, `users list`) because only `records` was unwrapped, not `results`
- **`--dry-run` broken for approve/decline**: `decline --dry-run` errored on confirmation; `approve --dry-run` silently executed the real action. Removed hardcoded `isWriteAction()` gate so `--dry-run` always shows a preview
- **`qbit status show` UX**: Single-action resources now auto-run their action, so `tsarr qbit status` works directly (while `status show` still works)
- **`qbit torrents list --json` too verbose**: JSON array output now applies `columns` by default, consistent with table/plain modes. `--select` overrides when provided

## Test plan

- [x] Manually verified all fixes against live qBittorrent and Jellyseerr instances
- [x] Added 6 unit tests for output formatter (select, quiet, plain, JSON columns, select override)
- [x] `bun test`, `tsc --noEmit`, `biome check` all pass

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-action resources can now be invoked directly without explicitly specifying the action subcommand.

* **Bug Fixes**
  * Dry-run flag now consistently applies across all action types, not just write operations.
  * Improved handling of paginated responses in command output.
  * Enhanced field selection in output with improved column filtering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->