### PR TITLE
fix(cli): fix duplicate output, doctor errors, and seerr display

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -81,6 +81,14 @@ export const doctor = defineCommand({
         }
         const client = factory(svcConfig);
         const status = await client.getSystemStatus();
+        if (status?.error !== undefined) {
+          const err = status.error;
+          const cause = err?.code ? { code: err.code } : undefined;
+          throw Object.assign(
+            new Error(err?.message ?? err?.code ?? 'Unknown API error'),
+            cause ? { cause } : {}
+          );
+        }
         const version = extractVersion(service, status) ?? '?';
         if (version === '?') {
           throw new Error('Unexpected response payload');
@@ -128,14 +136,22 @@ function classifyError(error: unknown): string {
   const msg = error.message;
   const cause = (error as any).cause;
 
-  // Connection errors
-  if (cause?.code === 'ECONNREFUSED' || msg.includes('ECONNREFUSED')) {
+  // Connection errors (Node.js error codes and hey-api client codes)
+  if (
+    cause?.code === 'ECONNREFUSED' ||
+    cause?.code === 'ConnectionRefused' ||
+    msg.includes('ECONNREFUSED')
+  ) {
     return 'Connection refused - is the service running?';
   }
   if (cause?.code === 'ENOTFOUND' || msg.includes('ENOTFOUND')) {
     return 'Host not found - check the URL';
   }
-  if (cause?.code === 'ECONNRESET' || msg.includes('ECONNRESET')) {
+  if (
+    cause?.code === 'ECONNRESET' ||
+    cause?.code === 'ConnectionReset' ||
+    msg.includes('ECONNRESET')
+  ) {
     return 'Connection reset - service may have crashed';
   }
   if (cause?.code === 'ETIMEDOUT' || msg.includes('ETIMEDOUT') || msg.includes('timed out')) {

--- a/src/cli/commands/seerr.ts
+++ b/src/cli/commands/seerr.ts
@@ -19,7 +19,19 @@ export const resources: ResourceDef[] = [
         ],
         columns: ['id', 'status', 'requestedBy', 'createdAt', 'updatedAt'],
         idField: 'id',
-        run: (c: SeerrClient, a) => c.getRequests(a.filter ? { filter: a.filter } : undefined),
+        run: async (c: SeerrClient, a) => {
+          const result: any = await c.getRequests(a.filter ? { filter: a.filter } : undefined);
+          const data = result?.data ?? result;
+          const items = data?.results ?? data;
+          if (!Array.isArray(items)) return result;
+          return {
+            ...data,
+            results: items.map((r: any) => ({
+              ...r,
+              requestedBy: r.requestedBy?.displayName ?? r.requestedBy?.email ?? r.requestedBy,
+            })),
+          };
+        },
       },
       {
         name: 'count',

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -195,8 +195,8 @@ export function buildServiceCommand(
 
     // When a resource has exactly one action, make it the default so
     // e.g. `tsarr qbit status` works without requiring `tsarr qbit status show`
-    const singleAction =
-      resource.actions.length === 1 ? actionCommands[resource.actions[0].name] : undefined;
+    const singleAction = resource.actions.length === 1 ? resource.actions[0] : undefined;
+    const singleActionCommand = singleAction ? actionCommands[singleAction.name] : undefined;
 
     subCommands[resource.name] = defineCommand({
       meta: {
@@ -204,7 +204,15 @@ export function buildServiceCommand(
         description: resource.description,
       },
       subCommands: actionCommands,
-      ...(singleAction ? { run: singleAction.run } : {}),
+      ...(singleActionCommand
+        ? {
+            run: (ctx: any) => {
+              // Skip if the subcommand name is explicitly in argv to avoid double execution
+              if (process.argv.includes(singleAction!.name)) return;
+              return singleActionCommand.run!(ctx);
+            },
+          }
+        : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

- **Fix duplicate output for single-action resources**: Commands like `calendar list`, `history list`, `status show` printed output twice when using the full `resource action` path because citty executed both the parent and child `run` handlers. The parent now skips execution when the subcommand is explicitly in argv.
- **Fix doctor error classification for unreachable services**: When a service is down, `tsarr doctor` showed "Unexpected response payload" instead of a meaningful error. Now checks hey-api error responses before version extraction and handles `ConnectionRefused`/`ConnectionReset` codes.
- **Fix seerr requests list requestedBy column**: Showed raw JSON user objects instead of display names. Now flattens `requestedBy` to show `displayName` or `email`.

## Test plan

- [x] `bun test` — 140 pass, 0 fail
- [x] `tsc --noEmit` — clean
- [x] `biome check` — clean
- [x] Manual testing against live Sonarr, Radarr, Prowlarr, qBittorrent, Jellyseerr instances
- [x] Verified single-action shortcut (`sonarr calendar`) and full path (`sonarr calendar list`) both produce single output
- [x] Verified `tsarr doctor` shows "Connection refused" for unreachable Bazarr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error detection in the doctor command for API failures with improved error classification for connection issues
  * Resolved potential duplicate execution of single-action commands
  * Improved request list data formatting and display normalization for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->