### PR TITLE
fix(cli): handle Node.js fetch errors for unreachable services

### DIFF
--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -321,9 +321,37 @@ function handleError(error: unknown, serviceName: string): never {
   } else if (error instanceof TsarrError) {
     consola.error(`Error: ${error.message}`);
   } else if (error instanceof Error) {
-    consola.error(error.message);
+    const networkMsg = classifyNetworkError(error, serviceName);
+    if (networkMsg) {
+      consola.error(`${networkMsg}\nRun \`tsarr doctor\` to diagnose.`);
+    } else {
+      consola.error(error.message);
+    }
   } else {
     consola.error('An unexpected error occurred.');
   }
   process.exit(1);
+}
+
+function classifyNetworkError(error: Error, serviceName: string): string | null {
+  const cause = (error as any).cause;
+  const code = cause?.code ?? (error as any).code;
+  const msg = error.message;
+
+  if (code === 'ECONNREFUSED' || code === 'ConnectionRefused') {
+    return `Connection refused. Is ${serviceName} running?`;
+  }
+  if (code === 'ENOTFOUND') {
+    return `Host not found for ${serviceName}. Check the URL.`;
+  }
+  if (code === 'ECONNRESET' || code === 'ConnectionReset') {
+    return `Connection reset. ${serviceName} may have crashed.`;
+  }
+  if (code === 'ETIMEDOUT') {
+    return `Connection timed out for ${serviceName}.`;
+  }
+  if (msg === 'fetch failed' || msg.includes('fetch failed')) {
+    return `Unable to reach ${serviceName}${cause?.message ? `: ${cause.message}` : ''}`;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Node.js `fetch` throws `TypeError: fetch failed` with the real error buried in `error.cause`, while Bun surfaces a friendlier message directly. Since the published package targets Node.js (>=18.20.8), users see a bare "fetch failed" when a service like Bazarr is unreachable.

Adds `classifyNetworkError()` to extract cause codes (ENOTFOUND, ECONNREFUSED, ECONNRESET, ETIMEDOUT) from thrown errors and show actionable messages like "Connection refused. Is bazarr running?" with a `tsarr doctor` suggestion.

## Test plan

- [x] `bun test` — 140 pass, 0 fail
- [x] `tsc --noEmit` / `biome check` — clean
- [x] Verified Bun path still shows improved errors
- [x] Node.js `fetch failed` errors now classified with service name and guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)