### PR TITLE
fix(cli): fix Node.js fetch error handling for unreachable services

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -83,11 +83,11 @@ export const doctor = defineCommand({
         const status = await client.getSystemStatus();
         if (status?.error !== undefined) {
           const err = status.error;
-          const cause = err?.code ? { code: err.code } : undefined;
-          throw Object.assign(
-            new Error(err?.message ?? err?.code ?? 'Unknown API error'),
-            cause ? { cause } : {}
-          );
+          // Node.js: TypeError with cause.code; Bun/hey-api: plain { code, message }
+          const code = err?.cause?.code ?? err?.code;
+          const cause = code ? { code } : undefined;
+          const message = err?.cause?.message ?? err?.message ?? err?.code ?? 'Unknown API error';
+          throw Object.assign(new Error(message), cause ? { cause } : {});
         }
         const version = extractVersion(service, status) ?? '?';
         if (version === '?') {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -160,6 +160,13 @@ export function buildServiceCommand(
             // Check for API error responses
             if (raw?.error !== undefined) {
               const err = raw.error;
+              // Network errors: on Node.js, fetch returns TypeError with cause;
+              // on Bun, hey-api returns { code, message } objects
+              const networkMsg = classifyNetworkError(err, serviceName);
+              if (networkMsg) {
+                consola.error(`${networkMsg}\nRun \`tsarr doctor\` to diagnose.`);
+                process.exit(1);
+              }
               const status = err?.status ?? raw?.response?.status;
               if (status === 401) {
                 const authHint =
@@ -169,22 +176,6 @@ export function buildServiceCommand(
                 consola.error(`Unauthorized. ${authHint}`);
               } else if (status === 404) {
                 consola.error('Not found.');
-              } else if (!status && err?.code) {
-                // Network-level error from hey-api (e.g. ConnectionRefused, ConnectionReset)
-                const code = err.code;
-                if (code === 'ConnectionRefused' || code === 'ECONNREFUSED') {
-                  consola.error(
-                    `Connection refused. Is ${serviceName} running?\nRun \`tsarr doctor\` to diagnose.`
-                  );
-                } else if (code === 'ConnectionReset' || code === 'ECONNRESET') {
-                  consola.error(
-                    `Connection reset. ${serviceName} may have crashed.\nRun \`tsarr doctor\` to diagnose.`
-                  );
-                } else {
-                  consola.error(
-                    `${err?.message ?? `Network error (${code})`}\nRun \`tsarr doctor\` to diagnose.`
-                  );
-                }
               } else {
                 consola.error(err?.title ?? err?.message ?? `API error (${status ?? 'unknown'})`);
               }
@@ -333,10 +324,13 @@ function handleError(error: unknown, serviceName: string): never {
   process.exit(1);
 }
 
-function classifyNetworkError(error: Error, serviceName: string): string | null {
-  const cause = (error as any).cause;
-  const code = cause?.code ?? (error as any).code;
-  const msg = error.message;
+function classifyNetworkError(error: unknown, serviceName: string): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const err = error as Record<string, any>;
+  // Node.js: TypeError with cause.code; Bun/hey-api: plain object with code
+  const cause = err.cause;
+  const code = cause?.code ?? err.code;
+  const msg = err.message ?? '';
 
   if (code === 'ECONNREFUSED' || code === 'ConnectionRefused') {
     return `Connection refused. Is ${serviceName} running?`;


### PR DESCRIPTION
## Summary

Node.js `fetch` throws `TypeError("fetch failed")` with the real error code in `error.cause.code` (e.g. `ENOTFOUND`, `ECONNREFUSED`), while Bun puts it on `error.code` directly. The previous fix (#167) only checked `error.code`, so Node.js users (the published package target) still saw bare "fetch failed" for all unreachable services.

Now checks both `error.cause.code` and `error.code` in both the service command handler and the doctor, producing messages like "Host not found for bazarr. Check the URL." on both runtimes.

**Actually tested with `node dist/cli/index.js` this time**, not just Bun.

## Test plan

- [x] `bun test` — 140 pass
- [x] `tsc --noEmit` / `biome check` — clean
- [x] `node dist/cli/index.js bazarr system status --json` → "Host not found for bazarr"
- [x] `node dist/cli/index.js bazarr series list --json` → "Host not found for bazarr"
- [x] `node dist/cli/index.js bazarr provider list --json` → "Host not found for bazarr"
- [x] `node dist/cli/index.js doctor --json` → bazarr: "Host not found - check the URL"

🤖 Generated with [Claude Code](https://claude.com/claude-code)