### PR TITLE
feat(cli): add multi-instance support for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ export TSARR_RADARR_URL=http://localhost:7878
 export TSARR_RADARR_API_KEY=your-api-key
 ```
 
-Config is stored in `~/.config/tsarr/config.json` (global) or `.tsarr.json` (local project). Environment variables take priority over config files.
+Config is stored in `~/.config/tsarr/config.json` (global) or `.tsarr.json` (local project). Environment variables take priority over config files. You can configure multiple instances of the same service (e.g. a 4K and 1080p Radarr) — see the [CLI Guide](./docs/cli.md) for details.
 
 ### Usage
 
@@ -170,6 +170,9 @@ tsarr radarr movie search --term "Interstellar"
 tsarr sonarr series list
 tsarr prowlarr indexer list
 tsarr lidarr artist search --term "Radiohead"
+
+# Multi-instance: target a specific named instance
+tsarr radarr movie list --instance 4K
 
 # Output formats
 tsarr radarr movie list --table    # Table (default in terminal)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,7 +28,7 @@ The fastest way to get started:
 tsarr config init
 ```
 
-This walks you through selecting services, entering URLs and API keys, tests each connection, and saves to your chosen scope (global or local).
+This walks you through selecting services, entering URLs and API keys, tests each connection, and saves to your chosen scope (global or local). After configuring the first instance of a service, you'll be prompted to add additional named instances (e.g. a "4K" and "1080p" Radarr).
 
 ### Environment Variables
 
@@ -42,7 +42,7 @@ export TSARR_RADARR_API_KEY=your-api-key
 export TSARR_RADARR_TIMEOUT=30000
 ```
 
-The pattern is `TSARR_{SERVICE}_URL`, `TSARR_{SERVICE}_API_KEY`, and `TSARR_{SERVICE}_TIMEOUT` for each service.
+The pattern is `TSARR_{SERVICE}_URL`, `TSARR_{SERVICE}_API_KEY`, and `TSARR_{SERVICE}_TIMEOUT` for each service. Environment variables always apply to the first (default) instance only.
 
 qBittorrent uses username/password authentication instead of API keys:
 
@@ -61,30 +61,44 @@ tsarr config set services.radarr.apiKey your-api-key
 
 # Set values in local config (useful per-project)
 tsarr config set services.radarr.baseUrl http://localhost:7878 --local
+
+# Set values for a specific named instance
+tsarr config set services.radarr.4K.baseUrl http://localhost:7879
+tsarr config set services.radarr.4K.apiKey your-4k-api-key
 ```
 
 ### Config File Format
 
-Both global (`~/.config/tsarr/config.json`) and local (`.tsarr.json`) use the same format:
+Both global (`~/.config/tsarr/config.json`) and local (`.tsarr.json`) use the same format. A service can be configured as a single object (legacy) or as an array of named instances:
 
 ```json
 {
   "services": {
-    "radarr": {
-      "baseUrl": "http://localhost:7878",
-      "apiKey": "your-api-key",
-      "timeout": 30000
-    },
     "sonarr": {
       "baseUrl": "http://localhost:8989",
       "apiKey": "your-api-key"
-    }
+    },
+    "radarr": [
+      {
+        "name": "1080p",
+        "baseUrl": "http://localhost:7878",
+        "apiKey": "your-api-key",
+        "timeout": 30000
+      },
+      {
+        "name": "4K",
+        "baseUrl": "http://localhost:7879",
+        "apiKey": "your-4k-api-key"
+      }
+    ]
   },
   "defaults": {
     "output": "table"
   }
 }
 ```
+
+The single-object format is still fully supported. When you configure only one instance (without a name), it is saved as a plain object for backwards compatibility.
 
 ### Viewing Config
 
@@ -116,6 +130,22 @@ tsarr <service> <resource> <action> [options]
 ```
 
 All commands follow a consistent three-level hierarchy: service, resource, action.
+
+## Multi-Instance Services
+
+You can configure multiple instances of the same service (e.g. a 4K and a 1080p Radarr). Use the `--instance` / `-i` flag to target a specific instance:
+
+```bash
+# List movies from the 4K Radarr instance
+tsarr radarr movie list --instance 4K
+
+# Check status of a specific instance
+tsarr radarr system status -i 1080p
+```
+
+When `--instance` is omitted, the first (default) instance is used. If the requested instance is not found, the CLI lists available instance names.
+
+The `doctor` command automatically checks all instances and shows an "instance" column when multi-instance services are detected.
 
 ## Output Formats
 
@@ -165,6 +195,7 @@ tsarr radarr movie list | jq '.[0].title'
 | `--quiet` | `-q` | Output IDs only |
 | `--select` | | Cherry-pick fields in JSON mode (comma-separated) |
 | `--yes` | `-y` | Skip confirmation prompts (for automation) |
+| `--instance` | `-i` | Target a specific named instance (for multi-instance services) |
 
 ## Available Commands
 

--- a/skills/tsarr/SKILL.md
+++ b/skills/tsarr/SKILL.md
@@ -34,6 +34,7 @@ Manage Servarr apps through the `tsarr` CLI.
 - Fetch the current item before `edit` or `delete` when possible.
 - Avoid `--yes` on destructive commands unless the user explicitly wants non-interactive execution.
 - If the user says "Arr", "library", or "queue" without naming a service, clarify which service to use.
+- If a service has multiple named instances and the user doesn't specify which, clarify or default to the first instance.
 
 ## Routing
 

--- a/skills/tsarr/references/common-workflows.md
+++ b/skills/tsarr/references/common-workflows.md
@@ -9,12 +9,14 @@ Prefer:
 - `--plain` for TSV-style piping
 - `--quiet` when only IDs are needed
 - `--select=field1,field2` to reduce noisy JSON
+- `--instance <name>` / `-i <name>` to target a specific named instance (for multi-instance services)
 
 Examples:
 
 ```bash
 tsarr radarr movie list --json --select=title,year,monitored
 tsarr sonarr series list --quiet
+tsarr radarr movie list --instance 4K --json
 ```
 
 ## Health and status

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -157,6 +157,15 @@ tsarr seerr status show --json
 
 Seerr uses API key authentication. Configure via `tsarr config init` or environment variables `TSARR_SEERR_URL` and `TSARR_SEERR_API_KEY`.
 
+## Multi-instance services
+
+When a service has multiple named instances, append `--instance <name>` or `-i <name>` to target a specific one. Without `--instance`, the first (default) instance is used.
+
+```bash
+tsarr radarr movie list --instance 4K --json
+tsarr sonarr series list -i main --json
+```
+
 ## Mutation rules
 
 - Run `get` or `list` first when a delete or edit is requested.

--- a/skills/tsarr/references/setup.md
+++ b/skills/tsarr/references/setup.md
@@ -26,7 +26,24 @@ Set values manually with:
 tsarr config set services.radarr.baseUrl http://localhost:7878
 tsarr config set services.radarr.apiKey your-api-key
 tsarr config set services.radarr.baseUrl http://localhost:7878 --local
+
+# For named instances (multi-instance setups)
+tsarr config set services.radarr.4K.baseUrl http://localhost:7879
+tsarr config set services.radarr.4K.apiKey your-4k-api-key
 ```
+
+## Multi-instance services
+
+A service can have multiple named instances (e.g. a 4K and 1080p Radarr). The config file supports both a single object (legacy) and an array of named instances per service. Use `--instance` / `-i` to target a specific instance:
+
+```bash
+tsarr radarr movie list --instance 4K
+tsarr radarr system status -i 1080p
+```
+
+When `--instance` is omitted, the first (default) instance is used. Environment variables always apply to the first instance only.
+
+`tsarr doctor` automatically checks all instances and shows an "instance" column when multi-instance services are detected.
 
 ## Connectivity checks
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 import consola from 'consola';
-import type { TsarrCliConfig } from '../config';
+import type { ServiceConfig, TsarrCliConfig } from '../config';
 import {
   GLOBAL_CONFIG_PATH,
   getConfigValue,
@@ -11,7 +11,7 @@ import {
   saveLocalConfig,
   setConfigValue,
 } from '../config';
-import { promptIfMissing, promptMultiSelect, promptSelect } from '../prompt';
+import { promptConfirm, promptIfMissing, promptMultiSelect, promptSelect } from '../prompt';
 
 const DEFAULT_PORTS: Record<string, number> = {
   radarr: 7878,
@@ -23,6 +23,74 @@ const DEFAULT_PORTS: Record<string, number> = {
   qbittorrent: 8080,
   seerr: 5055,
 };
+
+async function configureInstance(service: string, instanceName?: string): Promise<ServiceConfig> {
+  const baseUrl = await promptIfMissing(
+    undefined,
+    `${service}${instanceName ? ` (${instanceName})` : ''} base URL (e.g. http://localhost:${DEFAULT_PORTS[service]})`
+  );
+
+  if (service === 'qbittorrent') {
+    const username = await promptIfMissing(undefined, `${service} username`);
+    const password = await promptIfMissing(undefined, `${service} password`);
+    const cfg: ServiceConfig = { baseUrl, username, password };
+    if (instanceName) cfg.name = instanceName;
+    return cfg;
+  }
+
+  const apiKey = await promptIfMissing(undefined, `${service} API key`);
+  const cfg: ServiceConfig = { baseUrl, apiKey };
+  if (instanceName) cfg.name = instanceName;
+  return cfg;
+}
+
+async function testConnection(service: string, serviceConfig: ServiceConfig): Promise<void> {
+  try {
+    if (service === 'qbittorrent') {
+      const { QBittorrentClient } = await import('../../clients/qbittorrent.js');
+      const client = new QBittorrentClient({
+        baseUrl: serviceConfig.baseUrl,
+        username: serviceConfig.username!,
+        password: serviceConfig.password!,
+      });
+      const status = await client.getSystemStatus();
+      consola.success(
+        `Connected to ${service}${serviceConfig.name ? ` (${serviceConfig.name})` : ''} v${status.version}`
+      );
+    } else {
+      const { RadarrClient } = await import('../../clients/radarr.js');
+      const { SonarrClient } = await import('../../clients/sonarr.js');
+      const { LidarrClient } = await import('../../clients/lidarr.js');
+      const { ReadarrClient } = await import('../../clients/readarr.js');
+      const { ProwlarrClient } = await import('../../clients/prowlarr.js');
+      const { BazarrClient } = await import('../../clients/bazarr.js');
+      const { SeerrClient } = await import('../../clients/seerr.js');
+
+      const factories: Record<string, (c: any) => any> = {
+        radarr: c => new RadarrClient(c),
+        sonarr: c => new SonarrClient(c),
+        lidarr: c => new LidarrClient(c),
+        readarr: c => new ReadarrClient(c),
+        prowlarr: c => new ProwlarrClient(c),
+        bazarr: c => new BazarrClient(c),
+        seerr: c => new SeerrClient(c),
+      };
+
+      const client = factories[service]?.(serviceConfig);
+      if (client) {
+        const status = await client.getSystemStatus();
+        const version = (status as any)?.data?.version ?? (status as any)?.version ?? '?';
+        consola.success(
+          `Connected to ${service}${serviceConfig.name ? ` (${serviceConfig.name})` : ''} v${version}`
+        );
+      }
+    }
+  } catch {
+    consola.warn(
+      `Could not connect to ${service}${serviceConfig.name ? ` (${serviceConfig.name})` : ''} — config saved anyway.`
+    );
+  }
+}
 
 const configInit = defineCommand({
   meta: {
@@ -56,58 +124,38 @@ const configInit = defineCommand({
 
     for (const service of selected) {
       console.log();
-      const baseUrl = await promptIfMissing(
-        undefined,
-        `${service} base URL (e.g. http://localhost:${DEFAULT_PORTS[service]})`
-      );
+      const instances: ServiceConfig[] = [];
 
-      if (service === 'qbittorrent') {
-        const username = await promptIfMissing(undefined, `${service} username`);
-        const password = await promptIfMissing(undefined, `${service} password`);
-        config.services[service] = { baseUrl, username, password };
+      // Configure first instance (no name needed initially)
+      const first = await configureInstance(service);
+      await testConnection(service, first);
+      instances.push(first);
 
-        try {
-          const { QBittorrentClient } = await import('../../clients/qbittorrent.js');
-          const client = new QBittorrentClient({ baseUrl, username, password });
-          const status = await client.getSystemStatus();
-          consola.success(`Connected to ${service} v${status.version}`);
-        } catch {
-          consola.warn(`Could not connect to ${service} — config saved anyway.`);
+      // Offer to add more instances
+      while (true) {
+        const addMore = await promptConfirm(`Add another ${service} instance?`);
+        if (!addMore) break;
+
+        // If the first instance doesn't have a name yet, prompt for one
+        if (instances.length === 1 && !instances[0].name) {
+          const firstName = await promptIfMissing(
+            undefined,
+            `Name for the existing ${service} instance (e.g. "main", "1080p")`
+          );
+          instances[0].name = firstName;
         }
-      } else {
-        const apiKey = await promptIfMissing(undefined, `${service} API key`);
-        config.services[service] = { baseUrl, apiKey };
 
-        try {
-          const { RadarrClient } = await import('../../clients/radarr.js');
-          const { SonarrClient } = await import('../../clients/sonarr.js');
-          const { LidarrClient } = await import('../../clients/lidarr.js');
-          const { ReadarrClient } = await import('../../clients/readarr.js');
-          const { ProwlarrClient } = await import('../../clients/prowlarr.js');
-          const { BazarrClient } = await import('../../clients/bazarr.js');
-
-          const { SeerrClient } = await import('../../clients/seerr.js');
-
-          const factories: Record<string, (c: any) => any> = {
-            radarr: c => new RadarrClient(c),
-            sonarr: c => new SonarrClient(c),
-            lidarr: c => new LidarrClient(c),
-            readarr: c => new ReadarrClient(c),
-            prowlarr: c => new ProwlarrClient(c),
-            bazarr: c => new BazarrClient(c),
-            seerr: c => new SeerrClient(c),
-          };
-
-          const client = factories[service]?.(config.services[service]);
-          if (client) {
-            const status = await client.getSystemStatus();
-            const version = (status as any)?.data?.version ?? (status as any)?.version ?? '?';
-            consola.success(`Connected to ${service} v${version}`);
-          }
-        } catch {
-          consola.warn(`Could not connect to ${service} — config saved anyway.`);
-        }
+        const newName = await promptIfMissing(
+          undefined,
+          `Name for the new ${service} instance (e.g. "4K")`
+        );
+        console.log();
+        const newInstance = await configureInstance(service, newName);
+        await testConnection(service, newInstance);
+        instances.push(newInstance);
       }
+
+      config.services[service] = instances;
     }
 
     const location = await promptSelect('Save config to:', [
@@ -180,9 +228,13 @@ const configShow = defineCommand({
     const config = loadConfig();
     const redacted = JSON.parse(JSON.stringify(config));
     if (redacted.services) {
-      for (const svc of Object.values(redacted.services) as any[]) {
-        if (svc?.apiKey) svc.apiKey = '*****';
-        if (svc?.password) svc.password = '*****';
+      for (const instances of Object.values(redacted.services) as any[]) {
+        if (Array.isArray(instances)) {
+          for (const svc of instances) {
+            if (svc?.apiKey) svc.apiKey = '*****';
+            if (svc?.password) svc.password = '*****';
+          }
+        }
       }
     }
     console.log(JSON.stringify(redacted, null, 2));

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,7 +8,7 @@ import { RadarrClient } from '../../clients/radarr';
 import { ReadarrClient } from '../../clients/readarr';
 import { SeerrClient } from '../../clients/seerr';
 import { SonarrClient } from '../../clients/sonarr';
-import { getServiceConfig, SERVICES } from '../config';
+import { getServiceConfig, getServiceInstances, SERVICES } from '../config';
 import { detectFormat, formatOutput } from '../output';
 
 const clientFactories: Record<
@@ -27,6 +27,7 @@ const clientFactories: Record<
 
 interface DoctorResult {
   service: string;
+  instance?: string;
   configured: boolean;
   status: 'ok' | 'fail' | 'not configured';
   version?: string;
@@ -55,9 +56,10 @@ export const doctor = defineCommand({
       consola.info('Checking connections...\n');
     }
 
+    let hasMultiInstance = false;
     for (const service of SERVICES) {
-      const svcConfig = getServiceConfig(service);
-      if (!svcConfig) {
+      const instances = getServiceInstances(service);
+      if (instances.length === 0) {
         results.push({
           service,
           configured: false,
@@ -66,36 +68,53 @@ export const doctor = defineCommand({
         continue;
       }
 
-      hasAny = true;
-      try {
-        const client = clientFactories[service](svcConfig);
-        const status = await client.getSystemStatus();
-        if (status?.error !== undefined) {
-          const err = status.error;
-          const code = err?.cause?.code ?? err?.code;
-          const cause = code ? { code } : undefined;
-          const message = err?.cause?.message ?? err?.message ?? err?.code ?? 'Unknown API error';
-          throw Object.assign(new Error(message), cause ? { cause } : {});
+      if (instances.length > 1) hasMultiInstance = true;
+
+      for (const inst of instances) {
+        const svcConfig = getServiceConfig(service, inst.name);
+        if (!svcConfig) {
+          results.push({
+            service,
+            ...(inst.name ? { instance: inst.name } : {}),
+            configured: false,
+            status: 'not configured',
+          });
+          continue;
         }
-        const version = extractVersion(service, status) ?? '?';
-        if (version === '?') {
-          throw new Error('Unexpected response payload');
+
+        hasAny = true;
+        try {
+          const client = clientFactories[service](svcConfig);
+          const status = await client.getSystemStatus();
+          if (status?.error !== undefined) {
+            const err = status.error;
+            const code = err?.cause?.code ?? err?.code;
+            const cause = code ? { code } : undefined;
+            const message = err?.cause?.message ?? err?.message ?? err?.code ?? 'Unknown API error';
+            throw Object.assign(new Error(message), cause ? { cause } : {});
+          }
+          const version = extractVersion(service, status) ?? '?';
+          if (version === '?') {
+            throw new Error('Unexpected response payload');
+          }
+          results.push({
+            service,
+            ...(inst.name ? { instance: inst.name } : {}),
+            configured: true,
+            status: 'ok',
+            version: String(version),
+            baseUrl: svcConfig.baseUrl,
+          });
+        } catch (error) {
+          results.push({
+            service,
+            ...(inst.name ? { instance: inst.name } : {}),
+            configured: true,
+            status: 'fail',
+            baseUrl: svcConfig.baseUrl,
+            error: classifyError(error),
+          });
         }
-        results.push({
-          service,
-          configured: true,
-          status: 'ok',
-          version: String(version),
-          baseUrl: svcConfig.baseUrl,
-        });
-      } catch (error) {
-        results.push({
-          service,
-          configured: true,
-          status: 'fail',
-          baseUrl: svcConfig.baseUrl,
-          error: classifyError(error),
-        });
       }
     }
 
@@ -105,9 +124,13 @@ export const doctor = defineCommand({
       consola.warn('\nNo services configured. Run `tsarr config init` to set up.');
     }
 
+    const columns = hasMultiInstance
+      ? ['service', 'instance', 'status', 'configured', 'version', 'baseUrl', 'error']
+      : ['service', 'status', 'configured', 'version', 'baseUrl', 'error'];
+
     formatOutput(results, {
       format,
-      columns: ['service', 'status', 'configured', 'version', 'baseUrl', 'error'],
+      columns,
       idField: 'service',
       select: args.select,
     });

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { ApiKeyError, ConnectionError, TsarrError } from '../../core/errors';
-import { getServiceConfig } from '../config';
+import { getServiceConfig, getServiceInstances } from '../config';
 import { detectFormat, formatOutput } from '../output';
 import { promptConfirm, promptIfMissing } from '../prompt';
 
@@ -69,6 +69,11 @@ export function buildServiceCommand(
             description: 'Cherry-pick fields (comma-separated, JSON mode)',
           },
           yes: { type: 'boolean', alias: 'y', description: 'Skip confirmation prompts' },
+          instance: {
+            type: 'string',
+            alias: 'i',
+            description: 'Instance name (for multi-instance services)',
+          },
           ...(action.args ?? []).reduce(
             (acc, arg) => {
               acc[arg.name] = {
@@ -83,15 +88,24 @@ export function buildServiceCommand(
           ),
         },
         async run({ args }) {
-          const config = getServiceConfig(serviceName);
+          const instanceName: string | undefined = args.instance;
+          const config = getServiceConfig(serviceName, instanceName);
           if (!config) {
-            const envHint =
-              serviceName === 'qbittorrent'
-                ? `TSARR_QBITTORRENT_URL, TSARR_QBITTORRENT_USERNAME, and TSARR_QBITTORRENT_PASSWORD`
-                : `TSARR_${serviceName.toUpperCase()}_URL and TSARR_${serviceName.toUpperCase()}_API_KEY`;
-            consola.error(
-              `${serviceName} is not configured. Run \`tsarr config init\` or set ${envHint} environment variables.`
-            );
+            if (instanceName) {
+              const available = getServiceInstances(serviceName)
+                .map(i => i.name)
+                .filter(Boolean);
+              const hint = available.length ? ` Available: ${available.join(', ')}` : '';
+              consola.error(`${serviceName} instance '${instanceName}' is not configured.${hint}`);
+            } else {
+              const envHint =
+                serviceName === 'qbittorrent'
+                  ? `TSARR_QBITTORRENT_URL, TSARR_QBITTORRENT_USERNAME, and TSARR_QBITTORRENT_PASSWORD`
+                  : `TSARR_${serviceName.toUpperCase()}_URL and TSARR_${serviceName.toUpperCase()}_API_KEY`;
+              consola.error(
+                `${serviceName} is not configured. Run \`tsarr config init\` or set ${envHint} environment variables.`
+              );
+            }
             process.exit(1);
           }
 
@@ -138,7 +152,14 @@ export function buildServiceCommand(
 
             if (dryRun) {
               formatOutput(
-                buildDryRunPreview(format, serviceName, resource.name, action.name, resolvedArgs),
+                buildDryRunPreview(
+                  format,
+                  serviceName,
+                  resource.name,
+                  action.name,
+                  resolvedArgs,
+                  instanceName
+                ),
                 {
                   format,
                   noHeader,
@@ -293,7 +314,8 @@ function buildDryRunPreview(
   serviceName: string,
   resourceName: string,
   actionName: string,
-  args: Record<string, any>
+  args: Record<string, any>,
+  instanceName?: string
 ) {
   const filteredArgs = Object.fromEntries(
     Object.entries(args).filter(
@@ -308,14 +330,18 @@ function buildDryRunPreview(
         key !== 'no-header' &&
         key !== 'noHeader' &&
         key !== 'dry-run' &&
-        key !== 'dryRun'
+        key !== 'dryRun' &&
+        key !== 'instance'
     )
   );
+
+  const serviceLabel = instanceName ? `${serviceName}[${instanceName}]` : serviceName;
 
   if (format === 'json') {
     return {
       dryRun: true,
       service: serviceName,
+      ...(instanceName ? { instance: instanceName } : {}),
       resource: resourceName,
       action: actionName,
       args: filteredArgs,
@@ -323,7 +349,7 @@ function buildDryRunPreview(
   }
 
   return {
-    message: `Dry run: would execute ${serviceName} ${resourceName} ${actionName}${formatDryRunArgs(filteredArgs)}`,
+    message: `Dry run: would execute ${serviceLabel} ${resourceName} ${actionName}${formatDryRunArgs(filteredArgs)}`,
   };
 }
 

--- a/src/cli/completions.ts
+++ b/src/cli/completions.ts
@@ -173,7 +173,8 @@ ${actionAssoc}
         '--json[Output as JSON]' \\
         '--table[Output as table]' \\
         '--quiet[Output IDs only]' \\
-        '--yes[Skip confirmation prompts]'
+        '--yes[Skip confirmation prompts]' \\
+        '--instance[Instance name for multi-instance services]:instance:'
       ;;
   esac
 }
@@ -221,7 +222,9 @@ ${actionCompletions}
 complete -c tsarr -l json -d "Output as JSON"
 complete -c tsarr -l table -d "Output as table"
 complete -c tsarr -l quiet -s q -d "Output IDs only"
-complete -c tsarr -l yes -s y -d "Skip confirmation prompts"`;
+complete -c tsarr -l yes -s y -d "Skip confirmation prompts"
+complete -c tsarr -l instance -s i -d "Instance name (multi-instance services)"
+`;
 }
 
 export const completions = defineCommand({

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import type { QBittorrentClientConfig, ServarrClientConfig } from '../core/types';
 
 export interface ServiceConfig {
+  name?: string;
   baseUrl: string;
   apiKey?: string;
   apiKeyFile?: string;
@@ -12,8 +13,17 @@ export interface ServiceConfig {
   timeout?: number;
 }
 
+/** Internal config — services always normalized to arrays */
 export interface TsarrCliConfig {
-  services: Record<string, ServiceConfig>;
+  services: Record<string, ServiceConfig[]>;
+  defaults?: {
+    output?: 'json' | 'table' | 'quiet';
+  };
+}
+
+/** On-disk format accepts both single object and array per service */
+interface RawTsarrCliConfig {
+  services?: Record<string, ServiceConfig | ServiceConfig[]>;
   defaults?: {
     output?: 'json' | 'table' | 'quiet';
   };
@@ -39,6 +49,7 @@ function normalizeServiceConfig(service: ServiceConfig | undefined): ServiceConf
   const normalized: ServiceConfig = {
     baseUrl: service.baseUrl ?? '',
     apiKey: service.apiKey ?? '',
+    ...(service.name ? { name: service.name } : {}),
     ...(service.apiKeyFile ? { apiKeyFile: service.apiKeyFile } : {}),
     ...(service.username ? { username: service.username } : {}),
     ...(service.password ? { password: service.password } : {}),
@@ -52,17 +63,30 @@ function normalizeServiceConfig(service: ServiceConfig | undefined): ServiceConf
   return normalized;
 }
 
-function normalizeConfig(config: Partial<TsarrCliConfig>): Partial<TsarrCliConfig> {
+function normalizeServiceEntry(entry: ServiceConfig | ServiceConfig[]): ServiceConfig[] {
+  if (Array.isArray(entry)) {
+    return entry
+      .map(item => normalizeServiceConfig(item))
+      .filter((item): item is ServiceConfig => item != null);
+  }
+  const normalized = normalizeServiceConfig(entry);
+  return normalized ? [normalized] : [];
+}
+
+function normalizeConfig(config: Partial<RawTsarrCliConfig>): Partial<TsarrCliConfig> {
   const services = Object.fromEntries(
     Object.entries(config.services ?? {})
-      .map(([name, service]) => [name, normalizeServiceConfig(service as ServiceConfig)])
-      .filter(([, service]) => service != null)
-  ) as Record<string, ServiceConfig>;
+      .map(([name, entry]) => [
+        name,
+        normalizeServiceEntry(entry as ServiceConfig | ServiceConfig[]),
+      ])
+      .filter(([, instances]) => (instances as ServiceConfig[]).length > 0)
+  ) as Record<string, ServiceConfig[]>;
 
-  return {
-    ...config,
-    ...(Object.keys(services).length > 0 ? { services } : {}),
-  };
+  const result: Partial<TsarrCliConfig> = {};
+  if (Object.keys(services).length > 0) result.services = services;
+  if (config.defaults) result.defaults = config.defaults;
+  return result;
 }
 
 function readJsonFile(path: string): Partial<TsarrCliConfig> {
@@ -71,7 +95,7 @@ function readJsonFile(path: string): Partial<TsarrCliConfig> {
 }
 
 function getEnvConfig(): Partial<TsarrCliConfig> {
-  const services: Record<string, Partial<ServiceConfig>> = {};
+  const services: Record<string, ServiceConfig[]> = {};
   for (const service of SERVICES) {
     const upper = service.toUpperCase();
     const baseUrl = process.env[`TSARR_${upper}_URL`];
@@ -89,12 +113,10 @@ function getEnvConfig(): Partial<TsarrCliConfig> {
     }
     if (timeout) partial.timeout = Number(timeout);
     if (Object.keys(partial).length > 0) {
-      services[service] = partial;
+      services[service] = [partial as ServiceConfig];
     }
   }
-  return Object.keys(services).length
-    ? { services: services as Record<string, ServiceConfig> }
-    : {};
+  return Object.keys(services).length ? { services } : {};
 }
 
 function findLocalConfigPath(): string | null {
@@ -108,33 +130,75 @@ function findLocalConfigPath(): string | null {
   }
 }
 
+function isArrayEntry(raw: unknown): boolean {
+  return Array.isArray(raw);
+}
+
 export function loadConfig(): TsarrCliConfig {
-  const global = readJsonFile(GLOBAL_CONFIG_PATH);
+  const globalRaw = readJsonFile(GLOBAL_CONFIG_PATH);
   const localPath = findLocalConfigPath();
-  const local = localPath ? readJsonFile(localPath) : {};
+  const localRaw = localPath ? readJsonFile(localPath) : {};
   const env = getEnvConfig();
 
-  // Merge: global -> local -> env (env wins)
-  // Deep-merge per service so env overrides don't discard file-based config fields
+  // Read raw (pre-normalized) files to detect array vs object format
+  let globalDiskRaw: Partial<RawTsarrCliConfig> = {};
+  let localDiskRaw: Partial<RawTsarrCliConfig> = {};
+  try {
+    if (existsSync(GLOBAL_CONFIG_PATH)) {
+      globalDiskRaw = JSON.parse(readFileSync(GLOBAL_CONFIG_PATH, 'utf-8'));
+    }
+  } catch {}
+  try {
+    if (localPath && existsSync(localPath)) {
+      localDiskRaw = JSON.parse(readFileSync(localPath, 'utf-8'));
+    }
+  } catch {}
+
   const allServiceNames = new Set([
-    ...Object.keys(global.services ?? {}),
-    ...Object.keys(local.services ?? {}),
+    ...Object.keys(globalRaw.services ?? {}),
+    ...Object.keys(localRaw.services ?? {}),
     ...Object.keys(env.services ?? {}),
   ]);
-  const services: Record<string, ServiceConfig> = {};
+
+  const services: Record<string, ServiceConfig[]> = {};
   for (const name of allServiceNames) {
-    services[name] = {
-      ...global.services?.[name],
-      ...local.services?.[name],
-      ...env.services?.[name],
-    } as ServiceConfig;
+    const globalInstances = globalRaw.services?.[name] ?? [];
+    const localInstances = localRaw.services?.[name] ?? [];
+    const envInstances = env.services?.[name] ?? [];
+
+    const globalIsArray = isArrayEntry(globalDiskRaw.services?.[name]);
+    const localIsArray = isArrayEntry(localDiskRaw.services?.[name]);
+
+    // If either side uses array format, local wins entirely (can't merge instance arrays)
+    if (globalIsArray || localIsArray) {
+      const base = localInstances.length > 0 ? localInstances : globalInstances;
+      // Merge env into the first/default instance
+      if (envInstances.length > 0 && base.length > 0) {
+        base[0] = { ...base[0], ...envInstances[0] };
+      } else if (envInstances.length > 0) {
+        services[name] = envInstances;
+        continue;
+      }
+      services[name] = base;
+    } else {
+      // Both are single objects — per-field merge (preserves current behavior)
+      const globalObj = globalInstances[0];
+      const localObj = localInstances[0];
+      const envObj = envInstances[0];
+      const merged = {
+        ...globalObj,
+        ...localObj,
+        ...envObj,
+      } as ServiceConfig;
+      services[name] = [merged];
+    }
   }
 
   const merged: TsarrCliConfig = {
     services,
     defaults: {
-      ...global.defaults,
-      ...local.defaults,
+      ...globalRaw.defaults,
+      ...localRaw.defaults,
     },
   };
 
@@ -150,22 +214,32 @@ function resolveConfigRelativePath(filePath: string, configPath: string | null):
 
 function getResolvedApiKeyFilePath(
   serviceName: string,
-  service: ServiceConfig,
+  instance: ServiceConfig,
   localPath: string | null,
   local: Partial<TsarrCliConfig>,
   global: Partial<TsarrCliConfig>
 ): string | undefined {
-  if (!service.apiKeyFile) return undefined;
+  if (!instance.apiKeyFile) return undefined;
 
-  if (local.services?.[serviceName]?.apiKeyFile) {
-    return resolveConfigRelativePath(service.apiKeyFile, localPath);
+  // Check if the apiKeyFile was defined in local config
+  const localInstances = local.services?.[serviceName] ?? [];
+  const localMatch = localInstances.find(
+    i => i.apiKeyFile && (instance.name ? i.name === instance.name : true)
+  );
+  if (localMatch) {
+    return resolveConfigRelativePath(instance.apiKeyFile, localPath);
   }
 
-  if (global.services?.[serviceName]?.apiKeyFile) {
-    return resolveConfigRelativePath(service.apiKeyFile, GLOBAL_CONFIG_PATH);
+  // Check if defined in global config
+  const globalInstances = global.services?.[serviceName] ?? [];
+  const globalMatch = globalInstances.find(
+    i => i.apiKeyFile && (instance.name ? i.name === instance.name : true)
+  );
+  if (globalMatch) {
+    return resolveConfigRelativePath(instance.apiKeyFile, GLOBAL_CONFIG_PATH);
   }
 
-  return service.apiKeyFile;
+  return instance.apiKeyFile;
 }
 
 function readApiKeyFile(filePath: string): string {
@@ -181,29 +255,52 @@ function readApiKeyFile(filePath: string): string {
   }
 }
 
+/** Returns all instances for a service (normalized, always an array). */
+export function getServiceInstances(serviceName: string): ServiceConfig[] {
+  const config = loadConfig();
+  return config.services[serviceName] ?? [];
+}
+
+/** Returns instance names for a service. */
+export function getInstanceNames(serviceName: string): string[] {
+  return getServiceInstances(serviceName)
+    .map(i => i.name)
+    .filter((n): n is string => !!n);
+}
+
+function resolveInstance(
+  instances: ServiceConfig[],
+  instanceName?: string
+): ServiceConfig | undefined {
+  if (!instances.length) return undefined;
+  if (!instanceName) return instances[0];
+  return instances.find(i => i.name?.toLowerCase() === instanceName.toLowerCase());
+}
+
 export function getServiceConfig(
-  serviceName: string
+  serviceName: string,
+  instanceName?: string
 ): ServarrClientConfig | QBittorrentClientConfig | null {
   const global = readJsonFile(GLOBAL_CONFIG_PATH);
   const localPath = findLocalConfigPath();
   const local = localPath ? readJsonFile(localPath) : {};
   const config = loadConfig();
-  const service = config.services[serviceName];
-  if (!service?.baseUrl) return null;
+  const instances = config.services[serviceName] ?? [];
+  const instance = resolveInstance(instances, instanceName);
+  if (!instance?.baseUrl) return null;
 
   if (serviceName === 'qbittorrent') {
-    if (!service.username || !service.password) return null;
+    if (!instance.username || !instance.password) return null;
     return {
-      baseUrl: service.baseUrl,
-      username: service.username,
-      password: service.password,
-      ...(service.timeout ? { timeout: service.timeout } : {}),
+      baseUrl: instance.baseUrl,
+      username: instance.username,
+      password: instance.password,
+      ...(instance.timeout ? { timeout: instance.timeout } : {}),
     };
   }
 
-  // Priority: env var (already merged via getEnvConfig) > apiKeyFile > apiKey
-  let apiKey = service.apiKey;
-  const apiKeyFilePath = getResolvedApiKeyFilePath(serviceName, service, localPath, local, global);
+  let apiKey = instance.apiKey;
+  const apiKeyFilePath = getResolvedApiKeyFilePath(serviceName, instance, localPath, local, global);
   if (!apiKey && apiKeyFilePath) {
     apiKey = readApiKeyFile(apiKeyFilePath);
   }
@@ -211,30 +308,66 @@ export function getServiceConfig(
   if (!apiKey) return null;
 
   return {
-    baseUrl: service.baseUrl,
+    baseUrl: instance.baseUrl,
     apiKey,
-    ...(service.timeout ? { timeout: service.timeout } : {}),
+    ...(instance.timeout ? { timeout: instance.timeout } : {}),
   };
+}
+
+/** Serialize config for saving — single instances saved as objects for backwards compat */
+function serializeForDisk(config: TsarrCliConfig): RawTsarrCliConfig {
+  const services: Record<string, ServiceConfig | ServiceConfig[]> = {};
+  for (const [name, instances] of Object.entries(config.services)) {
+    if (instances.length === 1 && !instances[0].name) {
+      // Single unnamed instance — save as plain object
+      const { name: _name, ...rest } = instances[0];
+      services[name] = rest;
+    } else {
+      services[name] = instances;
+    }
+  }
+  return { services, defaults: config.defaults };
 }
 
 export function saveGlobalConfig(config: TsarrCliConfig): void {
   mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true });
-  writeFileSync(GLOBAL_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+  writeFileSync(GLOBAL_CONFIG_PATH, `${JSON.stringify(serializeForDisk(config), null, 2)}\n`);
 }
 
 export function saveLocalConfig(config: TsarrCliConfig): void {
   const existingPath = findLocalConfigPath();
   const targetPath = existingPath ?? join(process.cwd(), LOCAL_CONFIG_NAME);
-  writeFileSync(targetPath, `${JSON.stringify(config, null, 2)}\n`);
+  writeFileSync(targetPath, `${JSON.stringify(serializeForDisk(config), null, 2)}\n`);
+}
+
+function resolveArrayPath(instances: ServiceConfig[], segment: string): ServiceConfig | undefined {
+  // Try matching by instance name
+  const byName = instances.find(i => i.name === segment);
+  if (byName) return byName;
+  // Try matching by index
+  const idx = Number(segment);
+  if (Number.isInteger(idx) && idx >= 0 && idx < instances.length) return instances[idx];
+  return undefined;
 }
 
 export function getConfigValue(key: string): string | undefined {
   const config = loadConfig();
   const parts = key.split('.');
   let current: any = config;
-  for (const part of parts) {
+  for (let i = 0; i < parts.length; i++) {
     if (current == null || typeof current !== 'object') return undefined;
-    current = current[part];
+    if (Array.isArray(current)) {
+      // Try to resolve via instance name or index
+      const resolved = resolveArrayPath(current, parts[i]);
+      if (resolved) {
+        current = resolved;
+        continue;
+      }
+      // Fall back to default instance (index 0) and retry current segment
+      current = current[0]?.[parts[i]];
+    } else {
+      current = current[parts[i]];
+    }
   }
   return current != null ? String(current) : undefined;
 }
@@ -243,21 +376,36 @@ export function setConfigValue(key: string, value: string, global = true): void 
   const configPath = global
     ? GLOBAL_CONFIG_PATH
     : (findLocalConfigPath() ?? join(process.cwd(), LOCAL_CONFIG_NAME));
-  const config = readJsonFile(configPath) as any;
+  const raw = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
   const parts = key.split('.');
-  let current = config;
+  let current = raw;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (current[parts[i]] == null || typeof current[parts[i]] !== 'object') {
-      current[parts[i]] = {};
+    const part = parts[i];
+    if (Array.isArray(current[part])) {
+      // Navigate into array by instance name or index
+      const nextPart = parts[i + 1];
+      const resolved = resolveArrayPath(current[part], nextPart);
+      if (resolved) {
+        current = resolved;
+        i++; // skip the instance name segment
+        continue;
+      }
+      // Fall back to first element
+      current = current[part][0];
+      continue;
     }
-    current = current[parts[i]];
+    if (current[part] == null || typeof current[part] !== 'object') {
+      current[part] = {};
+    }
+    current = current[part];
   }
   current[parts[parts.length - 1]] = parseConfigValue(key, value);
 
   if (global) {
-    saveGlobalConfig(config as TsarrCliConfig);
+    mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true });
+    writeFileSync(configPath, `${JSON.stringify(raw, null, 2)}\n`);
   } else {
-    saveLocalConfig(config as TsarrCliConfig);
+    writeFileSync(configPath, `${JSON.stringify(raw, null, 2)}\n`);
   }
 }
 
@@ -276,9 +424,12 @@ function parseConfigValue(key: string, value: string): string | number {
 export function getConfiguredServices(): string[] {
   const config = loadConfig();
   return Object.entries(config.services)
-    .filter(
-      ([name, s]) =>
-        s.baseUrl && (name === 'qbittorrent' ? s.username && s.password : s.apiKey || s.apiKeyFile)
+    .filter(([name, instances]) =>
+      instances.some(
+        s =>
+          s.baseUrl &&
+          (name === 'qbittorrent' ? s.username && s.password : s.apiKey || s.apiKeyFile)
+      )
     )
     .map(([name]) => name);
 }

--- a/tests/config-api-key-file.test.ts
+++ b/tests/config-api-key-file.test.ts
@@ -135,7 +135,7 @@ describe('apiKeyFile support', () => {
       };
 
       expect(storedConfig.services.radarr.timeout).toBe(30000);
-      expect(loadConfig().services.radarr.timeout).toBe(30000);
+      expect(loadConfig().services.radarr[0].timeout).toBe(30000);
     });
   });
 });

--- a/tests/config-multi-instance.test.ts
+++ b/tests/config-multi-instance.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getConfigValue,
+  getInstanceNames,
+  getServiceConfig,
+  getServiceInstances,
+  LOCAL_CONFIG_NAME,
+  loadConfig,
+  saveLocalConfig,
+  setConfigValue,
+} from '../src/cli/config.js';
+
+describe('multi-instance support', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'tsarr-multi-'));
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    // Clear all TSARR env vars
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('TSARR_')) delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('legacy single-object config', () => {
+    it('should load single-object config unchanged', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: { baseUrl: 'http://localhost:7878', apiKey: 'key1' },
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = loadConfig();
+      expect(config.services.radarr).toHaveLength(1);
+      expect(config.services.radarr[0].baseUrl).toBe('http://localhost:7878');
+      expect(config.services.radarr[0].apiKey).toBe('key1');
+      expect(config.services.radarr[0].name).toBeUndefined();
+    });
+
+    it('should return correct service config for single instance', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: { baseUrl: 'http://localhost:7878', apiKey: 'key1' },
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = getServiceConfig('radarr');
+      expect(config).toEqual({
+        baseUrl: 'http://localhost:7878',
+        apiKey: 'key1',
+      });
+    });
+  });
+
+  describe('array config with named instances', () => {
+    it('should load array config correctly', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = loadConfig();
+      expect(config.services.radarr).toHaveLength(2);
+      expect(config.services.radarr[0].name).toBe('4K');
+      expect(config.services.radarr[1].name).toBe('1080p');
+    });
+
+    it('should return first instance when no instanceName given', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = getServiceConfig('radarr');
+      expect(config).toEqual({
+        baseUrl: 'http://localhost:7878',
+        apiKey: 'key-4k',
+      });
+    });
+
+    it('should return named instance when instanceName given', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = getServiceConfig('radarr', '1080p');
+      expect(config).toEqual({
+        baseUrl: 'http://localhost:7879',
+        apiKey: 'key-1080p',
+      });
+    });
+
+    it('should match instance names case-insensitively', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [{ name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' }],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = getServiceConfig('radarr', '4k');
+      expect(config).toEqual({
+        baseUrl: 'http://localhost:7878',
+        apiKey: 'key-4k',
+      });
+    });
+
+    it('should return null for nonexistent instance', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [{ name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' }],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const config = getServiceConfig('radarr', 'missing');
+      expect(config).toBeNull();
+    });
+  });
+
+  describe('getServiceInstances', () => {
+    it('should return all instances for a service', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const instances = getServiceInstances('radarr');
+      expect(instances).toHaveLength(2);
+      expect(instances[0].name).toBe('4K');
+      expect(instances[1].name).toBe('1080p');
+    });
+
+    it('should return single instance for service only in global config', () => {
+      // When no local config exists, instances come from global config (if any)
+      process.chdir(tempDir);
+      writeFileSync(join(tempDir, LOCAL_CONFIG_NAME), JSON.stringify({ services: {} }));
+      const instances = getServiceInstances('radarr');
+      // May find 0 or 1 depending on global config — just check it's an array
+      expect(Array.isArray(instances)).toBe(true);
+    });
+  });
+
+  describe('getInstanceNames', () => {
+    it('should return instance names', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      expect(getInstanceNames('radarr')).toEqual(['4K', '1080p']);
+    });
+
+    it('should return empty array for single unnamed instance', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: { baseUrl: 'http://localhost:7878', apiKey: 'key1' },
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      expect(getInstanceNames('radarr')).toEqual([]);
+    });
+  });
+
+  describe('env var override', () => {
+    it('should apply env vars to default instance only', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+      process.env.TSARR_RADARR_URL = 'http://env-override:7878';
+
+      const config = loadConfig();
+      // Env should override the first instance's URL
+      expect(config.services.radarr[0].baseUrl).toBe('http://env-override:7878');
+      // Second instance should be unchanged
+      expect(config.services.radarr[1].baseUrl).toBe('http://localhost:7879');
+    });
+  });
+
+  describe('save round-trip', () => {
+    it('should save single instance as object', () => {
+      process.chdir(tempDir);
+
+      saveLocalConfig({
+        services: {
+          radarr: [{ baseUrl: 'http://localhost:7878', apiKey: 'key1' }],
+        },
+      });
+
+      const raw = JSON.parse(readFileSync(join(tempDir, LOCAL_CONFIG_NAME), 'utf-8'));
+      // Should be saved as plain object, not array
+      expect(Array.isArray(raw.services.radarr)).toBe(false);
+      expect(raw.services.radarr.baseUrl).toBe('http://localhost:7878');
+    });
+
+    it('should save multiple instances as array', () => {
+      process.chdir(tempDir);
+
+      saveLocalConfig({
+        services: {
+          radarr: [
+            { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+            { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+          ],
+        },
+      });
+
+      const raw = JSON.parse(readFileSync(join(tempDir, LOCAL_CONFIG_NAME), 'utf-8'));
+      expect(Array.isArray(raw.services.radarr)).toBe(true);
+      expect(raw.services.radarr).toHaveLength(2);
+      expect(raw.services.radarr[0].name).toBe('4K');
+    });
+  });
+
+  describe('config value path resolution', () => {
+    it('should get value from default instance with simple path', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      expect(getConfigValue('services.radarr.baseUrl')).toBe('http://localhost:7878');
+    });
+
+    it('should get value from named instance', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      expect(getConfigValue('services.radarr.1080p.baseUrl')).toBe('http://localhost:7879');
+    });
+
+    it('should set value on named instance', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            radarr: [
+              { name: '4K', baseUrl: 'http://localhost:7878', apiKey: 'key-4k' },
+              { name: '1080p', baseUrl: 'http://localhost:7879', apiKey: 'key-1080p' },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      setConfigValue('services.radarr.1080p.baseUrl', 'http://new-url:7879', false);
+
+      const raw = JSON.parse(readFileSync(join(tempDir, LOCAL_CONFIG_NAME), 'utf-8'));
+      expect(raw.services.radarr[1].baseUrl).toBe('http://new-url:7879');
+      // First instance unchanged
+      expect(raw.services.radarr[0].baseUrl).toBe('http://localhost:7878');
+    });
+  });
+
+  describe('qbittorrent multi-instance', () => {
+    it('should support named qbittorrent instances', () => {
+      writeFileSync(
+        join(tempDir, LOCAL_CONFIG_NAME),
+        JSON.stringify({
+          services: {
+            qbittorrent: [
+              {
+                name: 'main',
+                baseUrl: 'http://localhost:8080',
+                username: 'admin',
+                password: 'pass1',
+              },
+              {
+                name: 'secondary',
+                baseUrl: 'http://localhost:8081',
+                username: 'admin',
+                password: 'pass2',
+              },
+            ],
+          },
+        })
+      );
+      process.chdir(tempDir);
+
+      const main = getServiceConfig('qbittorrent', 'main');
+      expect(main).toEqual({
+        baseUrl: 'http://localhost:8080',
+        username: 'admin',
+        password: 'pass1',
+      });
+
+      const secondary = getServiceConfig('qbittorrent', 'secondary');
+      expect(secondary).toEqual({
+        baseUrl: 'http://localhost:8081',
+        username: 'admin',
+        password: 'pass2',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the ability to configure multiple named instances of the same service (e.g. a 4K and 1080p Radarr) via `config init` or the array-based config format
- Adds `--instance` / `-i` flag to all service commands, with instance-aware error messages, dry-run output, and shell completions
- Updates `doctor` to check all instances per service and show an instance column when multi-instance services are detected
- Config layer rewritten to normalize both legacy single-object and new array formats, with backwards-compatible serialization
- Updates CLI docs, README, and ClawHub skill references to document multi-instance support

## Test plan
- [x] New `tests/config-multi-instance.test.ts` with 393 lines covering legacy loading, named instance selection, case-insensitive matching, env var overrides, save round-trips, and config get/set with instance paths
- [ ] Manual test: `tsarr config init` with multiple instances, verify config file format
- [ ] Manual test: `tsarr doctor` with multi-instance config shows instance column
- [ ] Manual test: `tsarr radarr movie list --instance <name>` targets correct instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--instance` / `-i` flag to target specific named instances of services (e.g., "4K" and "1080p" Radarr)
  * Interactive setup now allows configuring multiple named instances per service
  * `doctor` command now checks all instances and displays instance column for multi-instance services

* **Documentation**
  * Expanded CLI documentation with multi-instance configuration examples and usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->