### PR TITLE
feat(cli): add import list add/edit to Lidarr and Readarr

### DIFF
--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -509,6 +509,24 @@ const resources: ResourceDef[] = [
         run: (c: LidarrClient, a) => c.getImportList(a.id),
       },
       {
+        name: 'add',
+        description: 'Add an import list from JSON file or stdin',
+        args: [{ name: 'file', description: 'JSON file path (use - for stdin)', required: true }],
+        run: async (c: LidarrClient, a) => c.addImportList(readJsonInput(a.file)),
+      },
+      {
+        name: 'edit',
+        description: 'Edit an import list (merges JSON with existing)',
+        args: [
+          { name: 'id', description: 'Import list ID', required: true, type: 'number' },
+          { name: 'file', description: 'JSON file with fields to update', required: true },
+        ],
+        run: async (c: LidarrClient, a) => {
+          const existing = unwrapData<any>(await c.getImportList(a.id));
+          return c.updateImportList(a.id, { ...existing, ...readJsonInput(a.file) });
+        },
+      },
+      {
         name: 'delete',
         description: 'Delete an import list',
         args: [{ name: 'id', description: 'Import list ID', required: true, type: 'number' }],

--- a/src/cli/commands/readarr.ts
+++ b/src/cli/commands/readarr.ts
@@ -510,6 +510,24 @@ const resources: ResourceDef[] = [
         run: (c: ReadarrClient, a) => c.getImportList(a.id),
       },
       {
+        name: 'add',
+        description: 'Add an import list from JSON file or stdin',
+        args: [{ name: 'file', description: 'JSON file path (use - for stdin)', required: true }],
+        run: async (c: ReadarrClient, a) => c.addImportList(readJsonInput(a.file)),
+      },
+      {
+        name: 'edit',
+        description: 'Edit an import list (merges JSON with existing)',
+        args: [
+          { name: 'id', description: 'Import list ID', required: true, type: 'number' },
+          { name: 'file', description: 'JSON file with fields to update', required: true },
+        ],
+        run: async (c: ReadarrClient, a) => {
+          const existing = unwrapData<any>(await c.getImportList(a.id));
+          return c.updateImportList(a.id, { ...existing, ...readJsonInput(a.file) });
+        },
+      },
+      {
         name: 'delete',
         description: 'Delete an import list',
         args: [{ name: 'id', description: 'Import list ID', required: true, type: 'number' }],


### PR DESCRIPTION
## Summary
- Adds missing `add` and `edit` actions to the `importlist` CLI resource for Lidarr and Readarr
- Matches the existing implementation pattern from Radarr and Sonarr
- Both services already had the underlying client methods (`addImportList`, `updateImportList`)

Closes #172

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now supports creating new import lists in Lidarr and Readarr
  * CLI now supports editing existing import lists in both applications
  * Import list management and configuration can be performed entirely through the command-line
  * Users gain direct control over import list operations via extended CLI functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->