### PR TITLE
docs(cli): update documentation to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,14 @@ tsarr completions fish > ~/.config/fish/completions/tsarr.fish
 
 | Service | Resources |
 |---------|-----------|
-| `radarr` | movie, profile, tag, queue, rootfolder, system, history, customformat |
-| `sonarr` | series, episode, profile, tag, rootfolder, system |
-| `lidarr` | artist, album, profile, tag, rootfolder, system |
-| `readarr` | author, book, profile, tag, rootfolder, system |
-| `prowlarr` | indexer, search, app, tag, system |
+| `radarr` | movie, moviefile, profile, tag, queue, rootfolder, system, history, calendar, notification, downloadclient, blocklist, wanted, importlist, customformat |
+| `sonarr` | series, episode, episodefile, profile, tag, queue, rootfolder, system, history, calendar, notification, downloadclient, blocklist, wanted, importlist |
+| `lidarr` | artist, album, trackfile, profile, tag, queue, rootfolder, system, history, calendar, notification, downloadclient, blocklist, wanted, importlist |
+| `readarr` | author, book, bookfile, profile, tag, queue, rootfolder, system, history, calendar, notification, downloadclient, blocklist, wanted, importlist |
+| `prowlarr` | indexer, search, app, tag, indexerstats, notification, downloadclient, system |
 | `bazarr` | series, movie, episode, provider, language, system |
+| `qbittorrent` | torrents, status |
+| `seerr` | requests, search, users, status |
 
 See the [CLI Guide](./docs/cli.md) for full documentation including all commands, scripting examples, and shell completions.
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -21,6 +21,7 @@ These flags are available on all service resource actions:
 | `--select` | Cherry-pick fields in JSON mode (comma-separated, e.g. `--select=title,year`) |
 | `--yes` / `-y` | Skip confirmation prompts |
 | `--dry-run` | Show what would happen without executing |
+| `--instance` / `-i` | Target a specific named instance (for multi-instance services) |
 
 ## Radarr (Movies)
 
@@ -34,7 +35,13 @@ tsarr radarr <resource> <action> [args]
 | `movie` | `get` | `<id>` | Get movie by ID |
 | `movie` | `search` | `<term>` | Search TMDB for movies |
 | `movie` | `add` | `[term] [--tmdb-id <id>] [--quality-profile-id <id>] [--root-folder <path>]` | Add a movie interactively or by TMDB ID |
-| `movie` | `delete` | `<id>` | Delete a movie |
+| `movie` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit a movie |
+| `movie` | `refresh` | `<id>` | Refresh movie metadata |
+| `movie` | `manual-search` | `<id>` | Trigger a manual release search |
+| `movie` | `delete` | `<id> [--delete-files] [--add-import-exclusion]` | Delete a movie |
+| `moviefile` | `list` | `--movie-id <id>` | List files for a movie |
+| `moviefile` | `get` | `<id>` | Get movie file by ID |
+| `moviefile` | `delete` | `<id>` | Delete a movie file from disk |
 | `profile` | `list` | | List quality profiles |
 | `profile` | `get` | `<id>` | Get quality profile by ID |
 | `tag` | `create` | `<label>` | Create a tag |
@@ -42,10 +49,36 @@ tsarr radarr <resource> <action> [args]
 | `tag` | `list` | | List all tags |
 | `queue` | `list` | | Show download queue |
 | `queue` | `status` | | Queue overview |
+| `queue` | `delete` | `<id> [--blocklist] [--remove-from-client]` | Remove from queue |
+| `queue` | `grab` | `<id>` | Force download a queue item |
 | `rootfolder` | `list` | | List root folders |
+| `rootfolder` | `add` | `<path>` | Add a root folder |
+| `rootfolder` | `delete` | `<id>` | Delete a root folder |
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
-| `history` | `list` | | Recent activity |
+| `history` | `list` | `[--since <date>] [--until <date>]` | Recent activity (ISO 8601 date filtering) |
+| `calendar` | `list` | `[--start <date>] [--end <date>] [--unmonitored]` | Upcoming movie releases |
+| `notification` | `list` | | List notification providers |
+| `notification` | `get` | `<id>` | Get notification by ID |
+| `notification` | `add` | `<file>` | Add notification from JSON file or stdin |
+| `notification` | `edit` | `<id> <file>` | Edit notification (merges JSON) |
+| `notification` | `delete` | `<id>` | Delete a notification |
+| `notification` | `test` | | Test all notifications |
+| `downloadclient` | `list` | | List download clients |
+| `downloadclient` | `get` | `<id>` | Get download client by ID |
+| `downloadclient` | `add` | `<file>` | Add download client from JSON file or stdin |
+| `downloadclient` | `edit` | `<id> <file>` | Edit download client (merges JSON) |
+| `downloadclient` | `delete` | `<id>` | Delete a download client |
+| `downloadclient` | `test` | | Test all download clients |
+| `blocklist` | `list` | | List blocked releases |
+| `blocklist` | `delete` | `<id>` | Remove from blocklist |
+| `wanted` | `missing` | | Movies with missing files |
+| `wanted` | `cutoff` | | Movies below quality cutoff |
+| `importlist` | `list` | | List import lists |
+| `importlist` | `get` | `<id>` | Get import list by ID |
+| `importlist` | `add` | `<file>` | Add import list from JSON file or stdin |
+| `importlist` | `edit` | `<id> <file>` | Edit import list (merges JSON) |
+| `importlist` | `delete` | `<id>` | Delete an import list |
 | `customformat` | `list` | | List custom formats |
 
 ## Sonarr (TV Shows)
@@ -60,19 +93,53 @@ tsarr sonarr <resource> <action> [args]
 | `series` | `get` | `<id>` | Get series by ID |
 | `series` | `search` | `<term>` | Search for TV series |
 | `series` | `add` | `[term] [--tvdb-id <id>] [--quality-profile-id <id>] [--root-folder <path>]` | Add a series interactively or by TVDB ID |
-| `series` | `delete` | `<id>` | Delete a series |
+| `series` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit a series |
+| `series` | `refresh` | `<id>` | Refresh series metadata |
+| `series` | `manual-search` | `<id>` | Trigger a manual release search |
+| `series` | `delete` | `<id> [--delete-files] [--add-import-list-exclusion]` | Delete a series |
 | `episode` | `list` | `[--series-id <id>]` | List all episodes or filter by series |
 | `episode` | `get` | `<id>` | Get episode by ID |
+| `episode` | `search` | `<id>` | Trigger search for an episode |
+| `episodefile` | `list` | `--series-id <id>` | List files for a series |
+| `episodefile` | `get` | `<id>` | Get episode file by ID |
+| `episodefile` | `delete` | `<id>` | Delete an episode file from disk |
 | `profile` | `list` | | List quality profiles |
+| `profile` | `get` | `<id>` | Get quality profile by ID |
 | `tag` | `create` | `<label>` | Create a tag |
 | `tag` | `delete` | `<id>` | Delete a tag |
 | `tag` | `list` | | List all tags |
 | `queue` | `list` | `[--series-id <id>]` | Show download queue |
 | `queue` | `status` | | Queue overview |
-| `history` | `list` | `[--series-id <id>]` | Recent activity |
+| `queue` | `delete` | `<id> [--blocklist] [--remove-from-client]` | Remove from queue |
+| `queue` | `grab` | `<id>` | Force download a queue item |
 | `rootfolder` | `list` | | List root folders |
+| `rootfolder` | `add` | `<path>` | Add a root folder |
+| `rootfolder` | `delete` | `<id>` | Delete a root folder |
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
+| `history` | `list` | `[--series-id <id>] [--since <date>] [--until <date>]` | Recent activity (date filtering: ISO 8601) |
+| `calendar` | `list` | `[--start <date>] [--end <date>] [--unmonitored]` | Upcoming episode releases |
+| `notification` | `list` | | List notification providers |
+| `notification` | `get` | `<id>` | Get notification by ID |
+| `notification` | `add` | `<file>` | Add notification from JSON file or stdin |
+| `notification` | `edit` | `<id> <file>` | Edit notification (merges JSON) |
+| `notification` | `delete` | `<id>` | Delete a notification |
+| `notification` | `test` | | Test all notifications |
+| `downloadclient` | `list` | | List download clients |
+| `downloadclient` | `get` | `<id>` | Get download client by ID |
+| `downloadclient` | `add` | `<file>` | Add download client from JSON file or stdin |
+| `downloadclient` | `edit` | `<id> <file>` | Edit download client (merges JSON) |
+| `downloadclient` | `delete` | `<id>` | Delete a download client |
+| `downloadclient` | `test` | | Test all download clients |
+| `blocklist` | `list` | | List blocked releases |
+| `blocklist` | `delete` | `<id>` | Remove from blocklist |
+| `wanted` | `missing` | | Episodes with missing files |
+| `wanted` | `cutoff` | | Episodes below quality cutoff |
+| `importlist` | `list` | | List import lists |
+| `importlist` | `get` | `<id>` | Get import list by ID |
+| `importlist` | `add` | `<file>` | Add import list from JSON file or stdin |
+| `importlist` | `edit` | `<id> <file>` | Edit import list (merges JSON) |
+| `importlist` | `delete` | `<id>` | Delete an import list |
 
 ## Lidarr (Music)
 
@@ -85,17 +152,55 @@ tsarr lidarr <resource> <action> [args]
 | `artist` | `list` | | List all artists |
 | `artist` | `get` | `<id>` | Get artist by ID |
 | `artist` | `search` | `<term>` | Search for artists |
+| `artist` | `add` | `<term>` | Search and add an artist interactively |
+| `artist` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit an artist |
+| `artist` | `refresh` | `<id>` | Refresh artist metadata |
+| `artist` | `manual-search` | `<id>` | Trigger a manual release search |
 | `artist` | `delete` | `<id>` | Delete an artist |
 | `album` | `list` | | List all albums |
 | `album` | `get` | `<id>` | Get album by ID |
 | `album` | `search` | `<term>` | Search for albums |
+| `album` | `add` | `<file>` | Add album from JSON file or stdin |
+| `album` | `edit` | `<id> <file>` | Edit album (merges JSON) |
+| `album` | `delete` | `<id>` | Delete an album |
+| `trackfile` | `list` | `--artist-id <id>` | List files for an artist |
+| `trackfile` | `get` | `<id>` | Get track file by ID |
+| `trackfile` | `delete` | `<id>` | Delete a track file from disk |
 | `profile` | `list` | | List quality profiles |
+| `profile` | `get` | `<id>` | Get quality profile by ID |
 | `tag` | `create` | `<label>` | Create a tag |
 | `tag` | `delete` | `<id>` | Delete a tag |
 | `tag` | `list` | | List all tags |
+| `queue` | `list` | | Show download queue |
+| `queue` | `status` | | Queue overview |
+| `queue` | `delete` | `<id> [--blocklist] [--remove-from-client]` | Remove from queue |
+| `queue` | `grab` | `<id>` | Force download a queue item |
 | `rootfolder` | `list` | | List root folders |
+| `rootfolder` | `add` | `<path>` | Add a root folder |
+| `rootfolder` | `delete` | `<id>` | Delete a root folder |
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
+| `history` | `list` | `[--since <date>] [--until <date>]` | Recent activity (ISO 8601 date filtering) |
+| `calendar` | `list` | `[--start <date>] [--end <date>] [--unmonitored]` | Upcoming album releases |
+| `notification` | `list` | | List notification providers |
+| `notification` | `get` | `<id>` | Get notification by ID |
+| `notification` | `add` | `<file>` | Add notification from JSON file or stdin |
+| `notification` | `edit` | `<id> <file>` | Edit notification (merges JSON) |
+| `notification` | `delete` | `<id>` | Delete a notification |
+| `notification` | `test` | | Test all notifications |
+| `downloadclient` | `list` | | List download clients |
+| `downloadclient` | `get` | `<id>` | Get download client by ID |
+| `downloadclient` | `add` | `<file>` | Add download client from JSON file or stdin |
+| `downloadclient` | `edit` | `<id> <file>` | Edit download client (merges JSON) |
+| `downloadclient` | `delete` | `<id>` | Delete a download client |
+| `downloadclient` | `test` | | Test all download clients |
+| `blocklist` | `list` | | List blocked releases |
+| `blocklist` | `delete` | `<id>` | Remove from blocklist |
+| `wanted` | `missing` | | Albums with missing tracks |
+| `wanted` | `cutoff` | | Albums below quality cutoff |
+| `importlist` | `list` | | List import lists |
+| `importlist` | `get` | `<id>` | Get import list by ID |
+| `importlist` | `delete` | `<id>` | Delete an import list |
 
 ## Readarr (Books)
 
@@ -108,17 +213,55 @@ tsarr readarr <resource> <action> [args]
 | `author` | `list` | | List all authors |
 | `author` | `get` | `<id>` | Get author by ID |
 | `author` | `search` | `<term>` | Search for authors |
+| `author` | `add` | `<term>` | Search and add an author interactively |
+| `author` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit an author |
+| `author` | `refresh` | `<id>` | Refresh author metadata |
+| `author` | `manual-search` | `<id>` | Trigger a manual release search |
 | `author` | `delete` | `<id>` | Delete an author |
 | `book` | `list` | | List all books |
 | `book` | `get` | `<id>` | Get book by ID |
 | `book` | `search` | `<term>` | Search for books |
+| `book` | `add` | `<file>` | Add book from JSON file or stdin |
+| `book` | `edit` | `<id> <file>` | Edit book (merges JSON) |
+| `book` | `delete` | `<id>` | Delete a book |
+| `bookfile` | `list` | `--author-id <id>` | List files for an author |
+| `bookfile` | `get` | `<id>` | Get book file by ID |
+| `bookfile` | `delete` | `<id>` | Delete a book file from disk |
 | `profile` | `list` | | List quality profiles |
+| `profile` | `get` | `<id>` | Get quality profile by ID |
 | `tag` | `create` | `<label>` | Create a tag |
 | `tag` | `delete` | `<id>` | Delete a tag |
 | `tag` | `list` | | List all tags |
+| `queue` | `list` | | Show download queue |
+| `queue` | `status` | | Queue overview |
+| `queue` | `delete` | `<id> [--blocklist] [--remove-from-client]` | Remove from queue |
+| `queue` | `grab` | `<id>` | Force download a queue item |
 | `rootfolder` | `list` | | List root folders |
+| `rootfolder` | `add` | `<path>` | Add a root folder |
+| `rootfolder` | `delete` | `<id>` | Delete a root folder |
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
+| `history` | `list` | `[--since <date>] [--until <date>]` | Recent activity (ISO 8601 date filtering) |
+| `calendar` | `list` | `[--start <date>] [--end <date>] [--unmonitored]` | Upcoming book releases |
+| `notification` | `list` | | List notification providers |
+| `notification` | `get` | `<id>` | Get notification by ID |
+| `notification` | `add` | `<file>` | Add notification from JSON file or stdin |
+| `notification` | `edit` | `<id> <file>` | Edit notification (merges JSON) |
+| `notification` | `delete` | `<id>` | Delete a notification |
+| `notification` | `test` | | Test all notifications |
+| `downloadclient` | `list` | | List download clients |
+| `downloadclient` | `get` | `<id>` | Get download client by ID |
+| `downloadclient` | `add` | `<file>` | Add download client from JSON file or stdin |
+| `downloadclient` | `edit` | `<id> <file>` | Edit download client (merges JSON) |
+| `downloadclient` | `delete` | `<id>` | Delete a download client |
+| `downloadclient` | `test` | | Test all download clients |
+| `blocklist` | `list` | | List blocked releases |
+| `blocklist` | `delete` | `<id>` | Remove from blocklist |
+| `wanted` | `missing` | | Books with missing files |
+| `wanted` | `cutoff` | | Books below quality cutoff |
+| `importlist` | `list` | | List import lists |
+| `importlist` | `get` | `<id>` | Get import list by ID |
+| `importlist` | `delete` | `<id>` | Delete an import list |
 
 ## Prowlarr (Indexers)
 
@@ -130,13 +273,33 @@ tsarr prowlarr <resource> <action> [args]
 |----------|--------|------|-------------|
 | `indexer` | `list` | | List all indexers |
 | `indexer` | `get` | `<id>` | Get indexer by ID |
+| `indexer` | `add` | `<file>` | Add indexer from JSON file or stdin |
+| `indexer` | `edit` | `<id> <file>` | Edit indexer (merges JSON) |
 | `indexer` | `delete` | `<id>` | Delete an indexer |
+| `indexer` | `test` | `[--id <id>]` | Test one or all indexers |
 | `search` | `run` | `<term>` or `<query>` | Search across all indexers |
 | `app` | `list` | | List connected applications |
 | `app` | `get` | `<id>` | Get application by ID |
+| `app` | `add` | `<file>` | Add application from JSON file or stdin |
+| `app` | `edit` | `<id> <file>` | Edit application (merges JSON) |
+| `app` | `delete` | `<id>` | Delete an application |
+| `app` | `sync` | | Trigger app indexer sync |
+| `indexerstats` | `list` | | Get indexer performance statistics |
 | `tag` | `create` | `<label>` | Create a tag |
 | `tag` | `delete` | `<id>` | Delete a tag |
 | `tag` | `list` | | List all tags |
+| `notification` | `list` | | List notification providers |
+| `notification` | `get` | `<id>` | Get notification by ID |
+| `notification` | `add` | `<file>` | Add notification from JSON file or stdin |
+| `notification` | `edit` | `<id> <file>` | Edit notification (merges JSON) |
+| `notification` | `delete` | `<id>` | Delete a notification |
+| `notification` | `test` | | Test all notifications |
+| `downloadclient` | `list` | | List download clients |
+| `downloadclient` | `get` | `<id>` | Get download client by ID |
+| `downloadclient` | `add` | `<file>` | Add download client from JSON file or stdin |
+| `downloadclient` | `edit` | `<id> <file>` | Edit download client (merges JSON) |
+| `downloadclient` | `delete` | `<id>` | Delete a download client |
+| `downloadclient` | `test` | | Test all download clients |
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
 
@@ -157,6 +320,36 @@ tsarr bazarr <resource> <action> [args]
 | `system` | `status` | | System information |
 | `system` | `health` | | Health check issues |
 | `system` | `badges` | | Notification badges |
+
+## qBittorrent (Torrent Client)
+
+```bash
+tsarr qbit <resource> <action> [args]
+```
+
+| Resource | Action | Args | Description |
+|----------|--------|------|-------------|
+| `torrents` | `list` | `[--filter <state>]` | List torrents (filters: all, downloading, seeding, completed, paused, active, inactive, resumed, stalled, stalled_uploading, stalled_downloading, errored) |
+| `torrents` | `pause` | `<hashes>` | Pause torrents (comma-separated hashes or "all") |
+| `torrents` | `resume` | `<hashes>` | Resume torrents (comma-separated hashes or "all") |
+| `torrents` | `delete` | `<hashes> [--delete-files]` | Delete torrents (comma-separated hashes or "all") |
+| `status` | `show` | | Transfer info (speed, connections, DHT nodes) |
+
+## Seerr (Media Requests)
+
+```bash
+tsarr seerr <resource> <action> [args]
+```
+
+| Resource | Action | Args | Description |
+|----------|--------|------|-------------|
+| `requests` | `list` | `[--filter <status>]` | List media requests (filters: all, approved, available, pending, processing, unavailable, failed, deleted, completed) |
+| `requests` | `count` | | Get request count summary |
+| `requests` | `approve` | `<id>` | Approve a request |
+| `requests` | `decline` | `<id>` | Decline a request |
+| `search` | `query` | `<query>` | Search for movies and TV shows |
+| `users` | `list` | | List all users |
+| `status` | `show` | | Server status and version |
 
 ## Utility Commands
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,6 +206,11 @@ tsarr radarr movie list | jq '.[0].title'
 tsarr radarr movie list                        # List all movies
 tsarr radarr movie get --id 123                # Get movie by ID
 tsarr radarr movie search --term "Interstellar" # Search TMDB
+tsarr radarr movie add --term "Interstellar"   # Search and add interactively
+tsarr radarr movie add --tmdb-id 157336        # Add by TMDB ID directly
+tsarr radarr movie edit --id 123 --monitored false  # Edit a movie
+tsarr radarr movie refresh --id 123            # Refresh movie metadata
+tsarr radarr movie manual-search --id 123      # Trigger a manual release search
 tsarr radarr movie delete --id 123             # Delete (requires confirmation)
 tsarr radarr movie delete --id 123 --yes       # Delete without confirmation
 
@@ -220,13 +225,19 @@ tsarr radarr profile get --id 1                # Get profile details
 
 # Tags
 tsarr radarr tag list                          # List all tags
+tsarr radarr tag create --label "4k"           # Create a tag
+tsarr radarr tag delete --id 1                 # Delete a tag
 
 # Download queue
 tsarr radarr queue list                        # List queue items
 tsarr radarr queue status                      # Queue status
+tsarr radarr queue delete --id 1               # Remove from queue
+tsarr radarr queue grab --id 1                 # Force download a queue item
 
 # Root folders
 tsarr radarr rootfolder list                   # List root folders
+tsarr radarr rootfolder add --path /movies     # Add a root folder
+tsarr radarr rootfolder delete --id 1          # Delete a root folder
 
 # System
 tsarr radarr system status                     # System status
@@ -234,6 +245,43 @@ tsarr radarr system health                     # Health check results
 
 # History
 tsarr radarr history list                      # Recent history
+tsarr radarr history list --since 2024-01-01   # History since date (ISO 8601)
+tsarr radarr history list --until 2024-06-01   # History until date
+
+# Calendar
+tsarr radarr calendar list                     # List upcoming releases
+tsarr radarr calendar list --start 2024-01-01 --end 2024-02-01  # Date range
+
+# Notifications
+tsarr radarr notification list                 # List notification providers
+tsarr radarr notification get --id 1           # Get notification details
+tsarr radarr notification add config.json      # Add from JSON file
+tsarr radarr notification edit --id 1 update.json  # Edit notification
+tsarr radarr notification delete --id 1        # Delete a notification
+tsarr radarr notification test                 # Test all notifications
+
+# Download clients
+tsarr radarr downloadclient list               # List download clients
+tsarr radarr downloadclient get --id 1         # Get download client details
+tsarr radarr downloadclient add config.json    # Add from JSON file
+tsarr radarr downloadclient edit --id 1 update.json  # Edit download client
+tsarr radarr downloadclient delete --id 1      # Delete a download client
+tsarr radarr downloadclient test               # Test all download clients
+
+# Blocklist
+tsarr radarr blocklist list                    # List blocked releases
+tsarr radarr blocklist delete --id 1           # Remove from blocklist
+
+# Wanted
+tsarr radarr wanted missing                    # Movies with missing files
+tsarr radarr wanted cutoff                     # Movies below quality cutoff
+
+# Import lists
+tsarr radarr importlist list                   # List import lists
+tsarr radarr importlist get --id 1             # Get import list details
+tsarr radarr importlist add config.json        # Add from JSON file
+tsarr radarr importlist edit --id 1 update.json  # Edit import list
+tsarr radarr importlist delete --id 1          # Delete an import list
 
 # Custom formats
 tsarr radarr customformat list                 # List custom formats
@@ -246,23 +294,88 @@ tsarr radarr customformat list                 # List custom formats
 tsarr sonarr series list                       # List all series
 tsarr sonarr series get --id 1                 # Get series by ID
 tsarr sonarr series search --term "Breaking Bad" # Search
+tsarr sonarr series add --term "Breaking Bad"  # Search and add interactively
+tsarr sonarr series add --tvdb-id 81189        # Add by TVDB ID directly
+tsarr sonarr series edit --id 1 --monitored false  # Edit a series
+tsarr sonarr series refresh --id 1             # Refresh series metadata
+tsarr sonarr series manual-search --id 1       # Trigger a manual release search
 tsarr sonarr series delete --id 1              # Delete series
 
 # Episodes
 tsarr sonarr episode list                      # List all episodes
+tsarr sonarr episode list --series-id 1        # List episodes for a series
 tsarr sonarr episode get --id 1                # Get episode by ID
+tsarr sonarr episode search --id 1             # Trigger search for an episode
 
 # Episode files
 tsarr sonarr episodefile list --series-id 1    # List files for a series
 tsarr sonarr episodefile get --id 456          # Get episode file details
 tsarr sonarr episodefile delete --id 456       # Delete file from disk
 
-# Quality profiles, tags, root folders, system
-tsarr sonarr profile list
-tsarr sonarr tag list
-tsarr sonarr rootfolder list
-tsarr sonarr system status
-tsarr sonarr system health
+# Quality profiles
+tsarr sonarr profile list                      # List quality profiles
+tsarr sonarr profile get --id 1                # Get profile details
+
+# Tags
+tsarr sonarr tag list                          # List all tags
+tsarr sonarr tag create --label "anime"        # Create a tag
+tsarr sonarr tag delete --id 1                 # Delete a tag
+
+# Download queue
+tsarr sonarr queue list                        # List queue items
+tsarr sonarr queue list --series-id 1          # Queue items for a series
+tsarr sonarr queue status                      # Queue status
+tsarr sonarr queue delete --id 1               # Remove from queue
+tsarr sonarr queue grab --id 1                 # Force download a queue item
+
+# Root folders
+tsarr sonarr rootfolder list                   # List root folders
+tsarr sonarr rootfolder add --path /tv         # Add a root folder
+tsarr sonarr rootfolder delete --id 1          # Delete a root folder
+
+# System
+tsarr sonarr system status                     # System status
+tsarr sonarr system health                     # Health check results
+
+# History
+tsarr sonarr history list                      # Recent history
+tsarr sonarr history list --series-id 1        # History for a series
+tsarr sonarr history list --since 2024-01-01   # History since date (ISO 8601)
+
+# Calendar
+tsarr sonarr calendar list                     # List upcoming episodes
+tsarr sonarr calendar list --start 2024-01-01 --end 2024-02-01  # Date range
+
+# Notifications
+tsarr sonarr notification list                 # List notification providers
+tsarr sonarr notification get --id 1           # Get notification details
+tsarr sonarr notification add config.json      # Add from JSON file
+tsarr sonarr notification edit --id 1 update.json  # Edit notification
+tsarr sonarr notification delete --id 1        # Delete a notification
+tsarr sonarr notification test                 # Test all notifications
+
+# Download clients
+tsarr sonarr downloadclient list               # List download clients
+tsarr sonarr downloadclient get --id 1         # Get download client details
+tsarr sonarr downloadclient add config.json    # Add from JSON file
+tsarr sonarr downloadclient edit --id 1 update.json  # Edit download client
+tsarr sonarr downloadclient delete --id 1      # Delete a download client
+tsarr sonarr downloadclient test               # Test all download clients
+
+# Blocklist
+tsarr sonarr blocklist list                    # List blocked releases
+tsarr sonarr blocklist delete --id 1           # Remove from blocklist
+
+# Wanted
+tsarr sonarr wanted missing                    # Episodes with missing files
+tsarr sonarr wanted cutoff                     # Episodes below quality cutoff
+
+# Import lists
+tsarr sonarr importlist list                   # List import lists
+tsarr sonarr importlist get --id 1             # Get import list details
+tsarr sonarr importlist add config.json        # Add from JSON file
+tsarr sonarr importlist edit --id 1 update.json  # Edit import list
+tsarr sonarr importlist delete --id 1          # Delete an import list
 ```
 
 ### Lidarr
@@ -272,24 +385,85 @@ tsarr sonarr system health
 tsarr lidarr artist list                       # List all artists
 tsarr lidarr artist get --id 1                 # Get artist by ID
 tsarr lidarr artist search --term "Radiohead"  # Search
+tsarr lidarr artist add --term "Radiohead"     # Search and add interactively
+tsarr lidarr artist edit --id 1 --monitored false  # Edit an artist
+tsarr lidarr artist refresh --id 1             # Refresh artist metadata
+tsarr lidarr artist manual-search --id 1       # Trigger a manual release search
 tsarr lidarr artist delete --id 1              # Delete artist
 
 # Albums
 tsarr lidarr album list                        # List all albums
 tsarr lidarr album get --id 1                  # Get album by ID
 tsarr lidarr album search --term "OK Computer" # Search albums
+tsarr lidarr album add config.json             # Add from JSON file
+tsarr lidarr album edit --id 1 update.json     # Edit an album
+tsarr lidarr album delete --id 1               # Delete an album
 
 # Track files
 tsarr lidarr trackfile list --artist-id 1      # List files for an artist
 tsarr lidarr trackfile get --id 456            # Get track file details
 tsarr lidarr trackfile delete --id 456         # Delete file from disk
 
-# Quality profiles, tags, root folders, system
-tsarr lidarr profile list
-tsarr lidarr tag list
-tsarr lidarr rootfolder list
-tsarr lidarr system status
-tsarr lidarr system health
+# Quality profiles
+tsarr lidarr profile list                      # List quality profiles
+tsarr lidarr profile get --id 1                # Get profile details
+
+# Tags
+tsarr lidarr tag list                          # List all tags
+tsarr lidarr tag create --label "rock"         # Create a tag
+tsarr lidarr tag delete --id 1                 # Delete a tag
+
+# Download queue
+tsarr lidarr queue list                        # List queue items
+tsarr lidarr queue status                      # Queue status
+tsarr lidarr queue delete --id 1               # Remove from queue
+tsarr lidarr queue grab --id 1                 # Force download a queue item
+
+# Root folders
+tsarr lidarr rootfolder list                   # List root folders
+tsarr lidarr rootfolder add --path /music      # Add a root folder
+tsarr lidarr rootfolder delete --id 1          # Delete a root folder
+
+# System
+tsarr lidarr system status                     # System status
+tsarr lidarr system health                     # Health check results
+
+# History
+tsarr lidarr history list                      # Recent history
+tsarr lidarr history list --since 2024-01-01   # History since date (ISO 8601)
+
+# Calendar
+tsarr lidarr calendar list                     # List upcoming albums
+tsarr lidarr calendar list --start 2024-01-01 --end 2024-02-01  # Date range
+
+# Notifications
+tsarr lidarr notification list                 # List notification providers
+tsarr lidarr notification get --id 1           # Get notification details
+tsarr lidarr notification add config.json      # Add from JSON file
+tsarr lidarr notification edit --id 1 update.json  # Edit notification
+tsarr lidarr notification delete --id 1        # Delete a notification
+tsarr lidarr notification test                 # Test all notifications
+
+# Download clients
+tsarr lidarr downloadclient list               # List download clients
+tsarr lidarr downloadclient get --id 1         # Get download client details
+tsarr lidarr downloadclient add config.json    # Add from JSON file
+tsarr lidarr downloadclient edit --id 1 update.json  # Edit download client
+tsarr lidarr downloadclient delete --id 1      # Delete a download client
+tsarr lidarr downloadclient test               # Test all download clients
+
+# Blocklist
+tsarr lidarr blocklist list                    # List blocked releases
+tsarr lidarr blocklist delete --id 1           # Remove from blocklist
+
+# Wanted
+tsarr lidarr wanted missing                    # Albums with missing tracks
+tsarr lidarr wanted cutoff                     # Albums below quality cutoff
+
+# Import lists
+tsarr lidarr importlist list                   # List import lists
+tsarr lidarr importlist get --id 1             # Get import list details
+tsarr lidarr importlist delete --id 1          # Delete an import list
 ```
 
 ### Readarr
@@ -299,24 +473,85 @@ tsarr lidarr system health
 tsarr readarr author list                      # List all authors
 tsarr readarr author get --id 1                # Get author by ID
 tsarr readarr author search --term "Tolkien"   # Search
+tsarr readarr author add --term "Tolkien"      # Search and add interactively
+tsarr readarr author edit --id 1 --monitored false  # Edit an author
+tsarr readarr author refresh --id 1            # Refresh author metadata
+tsarr readarr author manual-search --id 1      # Trigger a manual release search
 tsarr readarr author delete --id 1             # Delete author
 
 # Books
 tsarr readarr book list                        # List all books
 tsarr readarr book get --id 1                  # Get book by ID
 tsarr readarr book search --term "Dune"        # Search books
+tsarr readarr book add config.json             # Add from JSON file
+tsarr readarr book edit --id 1 update.json     # Edit a book
+tsarr readarr book delete --id 1               # Delete a book
 
 # Book files
 tsarr readarr bookfile list --author-id 1      # List files for an author
 tsarr readarr bookfile get --id 456            # Get book file details
 tsarr readarr bookfile delete --id 456         # Delete file from disk
 
-# Quality profiles, tags, root folders, system
-tsarr readarr profile list
-tsarr readarr tag list
-tsarr readarr rootfolder list
-tsarr readarr system status
-tsarr readarr system health
+# Quality profiles
+tsarr readarr profile list                     # List quality profiles
+tsarr readarr profile get --id 1               # Get profile details
+
+# Tags
+tsarr readarr tag list                         # List all tags
+tsarr readarr tag create --label "scifi"       # Create a tag
+tsarr readarr tag delete --id 1                # Delete a tag
+
+# Download queue
+tsarr readarr queue list                       # List queue items
+tsarr readarr queue status                     # Queue status
+tsarr readarr queue delete --id 1              # Remove from queue
+tsarr readarr queue grab --id 1                # Force download a queue item
+
+# Root folders
+tsarr readarr rootfolder list                  # List root folders
+tsarr readarr rootfolder add --path /books     # Add a root folder
+tsarr readarr rootfolder delete --id 1         # Delete a root folder
+
+# System
+tsarr readarr system status                    # System status
+tsarr readarr system health                    # Health check results
+
+# History
+tsarr readarr history list                     # Recent history
+tsarr readarr history list --since 2024-01-01  # History since date (ISO 8601)
+
+# Calendar
+tsarr readarr calendar list                    # List upcoming books
+tsarr readarr calendar list --start 2024-01-01 --end 2024-02-01  # Date range
+
+# Notifications
+tsarr readarr notification list                # List notification providers
+tsarr readarr notification get --id 1          # Get notification details
+tsarr readarr notification add config.json     # Add from JSON file
+tsarr readarr notification edit --id 1 update.json  # Edit notification
+tsarr readarr notification delete --id 1       # Delete a notification
+tsarr readarr notification test                # Test all notifications
+
+# Download clients
+tsarr readarr downloadclient list              # List download clients
+tsarr readarr downloadclient get --id 1        # Get download client details
+tsarr readarr downloadclient add config.json   # Add from JSON file
+tsarr readarr downloadclient edit --id 1 update.json  # Edit download client
+tsarr readarr downloadclient delete --id 1     # Delete a download client
+tsarr readarr downloadclient test              # Test all download clients
+
+# Blocklist
+tsarr readarr blocklist list                   # List blocked releases
+tsarr readarr blocklist delete --id 1          # Remove from blocklist
+
+# Wanted
+tsarr readarr wanted missing                   # Books with missing files
+tsarr readarr wanted cutoff                    # Books below quality cutoff
+
+# Import lists
+tsarr readarr importlist list                  # List import lists
+tsarr readarr importlist get --id 1            # Get import list details
+tsarr readarr importlist delete --id 1         # Delete an import list
 ```
 
 ### Prowlarr
@@ -325,7 +560,11 @@ tsarr readarr system health
 # Indexers
 tsarr prowlarr indexer list                    # List all indexers
 tsarr prowlarr indexer get --id 1              # Get indexer details
+tsarr prowlarr indexer add config.json         # Add from JSON file
+tsarr prowlarr indexer edit --id 1 update.json # Edit an indexer
 tsarr prowlarr indexer delete --id 1           # Delete indexer
+tsarr prowlarr indexer test                    # Test all indexers
+tsarr prowlarr indexer test --id 1             # Test a specific indexer
 
 # Search
 tsarr prowlarr search run --query "ubuntu"     # Search across indexers
@@ -333,11 +572,38 @@ tsarr prowlarr search run --query "ubuntu"     # Search across indexers
 # Applications
 tsarr prowlarr app list                        # List configured apps
 tsarr prowlarr app get --id 1                  # Get app details
+tsarr prowlarr app add config.json             # Add from JSON file
+tsarr prowlarr app edit --id 1 update.json     # Edit an application
+tsarr prowlarr app delete --id 1               # Delete an application
+tsarr prowlarr app sync                        # Trigger app indexer sync
 
-# Tags, system
-tsarr prowlarr tag list
-tsarr prowlarr system status
-tsarr prowlarr system health
+# Indexer stats
+tsarr prowlarr indexerstats list               # Get indexer performance statistics
+
+# Tags
+tsarr prowlarr tag list                        # List all tags
+tsarr prowlarr tag create --label "public"     # Create a tag
+tsarr prowlarr tag delete --id 1               # Delete a tag
+
+# Notifications
+tsarr prowlarr notification list               # List notification providers
+tsarr prowlarr notification get --id 1         # Get notification details
+tsarr prowlarr notification add config.json    # Add from JSON file
+tsarr prowlarr notification edit --id 1 update.json  # Edit notification
+tsarr prowlarr notification delete --id 1      # Delete a notification
+tsarr prowlarr notification test               # Test all notifications
+
+# Download clients
+tsarr prowlarr downloadclient list             # List download clients
+tsarr prowlarr downloadclient get --id 1       # Get download client details
+tsarr prowlarr downloadclient add config.json  # Add from JSON file
+tsarr prowlarr downloadclient edit --id 1 update.json  # Edit download client
+tsarr prowlarr downloadclient delete --id 1    # Delete a download client
+tsarr prowlarr downloadclient test             # Test all download clients
+
+# System
+tsarr prowlarr system status                   # System status
+tsarr prowlarr system health                   # Health check results
 ```
 
 ### Bazarr
@@ -497,7 +763,7 @@ After adding completions, restart your shell or source the config file. Then pre
 ```
 tsarr r<TAB>        → radarr, readarr
 tsarr radarr m<TAB> → movie
-tsarr radarr movie <TAB> → list, get, search, delete
+tsarr radarr movie <TAB> → list, get, search, add, edit, refresh, manual-search, delete
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary

- Adds qBittorrent and Seerr to the README resources table and documents all their commands
- Documents missing resources across all services: notification, downloadclient, blocklist, wanted, importlist, calendar, and file resources (moviefile, episodefile, trackfile, bookfile)
- Documents missing actions: add, edit, refresh, manual-search, test, and history date filtering (`--since`/`--until`)
- Expands `docs/cli-commands.md` command reference tables to cover all implemented commands

Closes #171

## Test plan

- [ ] Verify documented commands match `tsarr <service> --help` output
- [ ] Spot-check a few newly documented commands against source in `src/cli/commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)