### PR TITLE
chore(config): remove deprecated baseUrl and unnecessary DOM.Iterable lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",
@@ -17,10 +17,8 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
-      "tsarr/*": ["src/*"]
+      "tsarr/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- Remove `baseUrl` and `ignoreDeprecations: "6.0"` from tsconfig by using relative paths (`"./src/*"`) in the `paths` alias
- Drop `DOM.Iterable` from `lib` since no DOM collections are used in this Node.js SDK
- Kept `ignoreUnknown: false` in biome.json as biome already handles `.mjs` natively — no change needed

Closes #178

## Test plan
- [x] `tsc --noEmit` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configuration to refine library targets and module path resolution settings.

---

**Note:** This release contains internal configuration updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->