### PR TITLE
test(cli): add coverage for Bazarr, Lidarr, Readarr, config, and completions

### DIFF
--- a/src/cli/commands/bazarr.ts
+++ b/src/cli/commands/bazarr.ts
@@ -2,7 +2,7 @@ import { BazarrClient } from '../../clients/bazarr';
 import type { ResourceDef } from './service';
 import { buildServiceCommand } from './service';
 
-const resources: ResourceDef[] = [
+export const resources: ResourceDef[] = [
   {
     name: 'series',
     description: 'Manage series subtitles',

--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -3,7 +3,7 @@ import { promptConfirm, promptSelect } from '../prompt';
 import type { ResourceDef } from './service';
 import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS, readJsonInput, unwrapData } from './service';
 
-const resources: ResourceDef[] = [
+export const resources: ResourceDef[] = [
   {
     name: 'artist',
     description: 'Manage artists',

--- a/src/cli/commands/readarr.ts
+++ b/src/cli/commands/readarr.ts
@@ -3,7 +3,7 @@ import { promptConfirm, promptSelect } from '../prompt';
 import type { ResourceDef } from './service';
 import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS, readJsonInput, unwrapData } from './service';
 
-const resources: ResourceDef[] = [
+export const resources: ResourceDef[] = [
   {
     name: 'author',
     description: 'Manage authors',

--- a/tests/cli-bazarr-defs.test.ts
+++ b/tests/cli-bazarr-defs.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { resources as bazarrResources } from '../src/cli/commands/bazarr.js';
+
+describe('Bazarr command definitions', () => {
+  it('defines series resource with list action', () => {
+    const series = bazarrResources.find(r => r.name === 'series');
+    expect(series).toBeDefined();
+    expect(series!.actions.map(a => a.name)).toEqual(['list']);
+  });
+
+  it('defines movie resource with list action', () => {
+    const movie = bazarrResources.find(r => r.name === 'movie');
+    expect(movie).toBeDefined();
+    expect(movie!.actions.map(a => a.name)).toEqual(['list']);
+  });
+
+  it('defines episode resource with wanted action', () => {
+    const episode = bazarrResources.find(r => r.name === 'episode');
+    expect(episode).toBeDefined();
+    expect(episode!.actions.map(a => a.name)).toEqual(['wanted']);
+  });
+
+  it('defines provider resource with list action', () => {
+    const provider = bazarrResources.find(r => r.name === 'provider');
+    expect(provider).toBeDefined();
+    expect(provider!.actions.map(a => a.name)).toEqual(['list']);
+  });
+
+  it('defines language resource with list and profiles actions', () => {
+    const language = bazarrResources.find(r => r.name === 'language');
+    expect(language).toBeDefined();
+    expect(language!.actions.map(a => a.name)).toEqual(['list', 'profiles']);
+  });
+
+  it('defines system resource with status, health, badges actions', () => {
+    const system = bazarrResources.find(r => r.name === 'system');
+    expect(system).toBeDefined();
+    expect(system!.actions.map(a => a.name)).toEqual(['status', 'health', 'badges']);
+  });
+
+  it('series list has expected columns', () => {
+    const series = bazarrResources.find(r => r.name === 'series');
+    const listAction = series!.actions.find(a => a.name === 'list');
+    expect(listAction!.columns).toEqual(['sonarrSeriesId', 'title', 'profileId']);
+  });
+
+  it('movie list has expected columns', () => {
+    const movie = bazarrResources.find(r => r.name === 'movie');
+    const listAction = movie!.actions.find(a => a.name === 'list');
+    expect(listAction!.columns).toEqual(['radarrId', 'title', 'profileId']);
+  });
+
+  it('episode wanted has expected columns', () => {
+    const episode = bazarrResources.find(r => r.name === 'episode');
+    const wantedAction = episode!.actions.find(a => a.name === 'wanted');
+    expect(wantedAction!.columns).toEqual(['sonarrEpisodeId', 'title', 'seriesTitle']);
+  });
+
+  it('language list has expected columns', () => {
+    const language = bazarrResources.find(r => r.name === 'language');
+    const listAction = language!.actions.find(a => a.name === 'list');
+    expect(listAction!.columns).toEqual(['code2', 'name', 'enabled']);
+  });
+
+  it('covers all expected resources', () => {
+    const names = bazarrResources.map(r => r.name).sort();
+    expect(names).toEqual(['episode', 'language', 'movie', 'provider', 'series', 'system']);
+  });
+});

--- a/tests/cli-completions.test.ts
+++ b/tests/cli-completions.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { completions } from '../src/cli/completions.js';
+
+describe('Shell completions', () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  beforeEach(() => {
+    logs.length = 0;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(' '));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  it('has correct command metadata', () => {
+    expect(completions.meta?.name).toBe('completions');
+    expect(completions.meta?.description).toBeDefined();
+  });
+
+  it('requires a shell positional argument', () => {
+    expect(completions.args?.shell?.type).toBe('positional');
+    expect(completions.args?.shell?.required).toBe(true);
+  });
+
+  describe('bash completions', () => {
+    it('generates bash completion script', () => {
+      completions.run!({ args: { shell: 'bash' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('_tsarr_completions');
+      expect(output).toContain('complete -F _tsarr_completions tsarr');
+    });
+
+    it('includes all services', () => {
+      completions.run!({ args: { shell: 'bash' } } as any);
+      const output = logs.join('\n');
+      for (const service of [
+        'radarr',
+        'sonarr',
+        'lidarr',
+        'readarr',
+        'prowlarr',
+        'bazarr',
+        'seerr',
+      ]) {
+        expect(output).toContain(service);
+      }
+    });
+
+    it('includes global commands', () => {
+      completions.run!({ args: { shell: 'bash' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('doctor');
+      expect(output).toContain('config');
+      expect(output).toContain('completions');
+    });
+
+    it('includes config subcommands', () => {
+      completions.run!({ args: { shell: 'bash' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('init set get show');
+    });
+  });
+
+  describe('zsh completions', () => {
+    it('generates zsh completion script', () => {
+      completions.run!({ args: { shell: 'zsh' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('#compdef tsarr');
+      expect(output).toContain('_tsarr');
+    });
+
+    it('includes service resources', () => {
+      completions.run!({ args: { shell: 'zsh' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('radarr');
+      expect(output).toContain('movie');
+      expect(output).toContain('artist');
+      expect(output).toContain('author');
+    });
+
+    it('includes global options', () => {
+      completions.run!({ args: { shell: 'zsh' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('--json');
+      expect(output).toContain('--table');
+      expect(output).toContain('--quiet');
+      expect(output).toContain('--yes');
+      expect(output).toContain('--instance');
+    });
+  });
+
+  describe('fish completions', () => {
+    it('generates fish completion script', () => {
+      completions.run!({ args: { shell: 'fish' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('complete -c tsarr');
+    });
+
+    it('includes service and global options', () => {
+      completions.run!({ args: { shell: 'fish' } } as any);
+      const output = logs.join('\n');
+      expect(output).toContain('radarr');
+      expect(output).toContain('config');
+      expect(output).toContain('-l json');
+      expect(output).toContain('-l table');
+      expect(output).toContain('-l quiet');
+    });
+  });
+});

--- a/tests/cli-lidarr-defs.test.ts
+++ b/tests/cli-lidarr-defs.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'bun:test';
+import { resources as lidarrResources } from '../src/cli/commands/lidarr.js';
+import { COMMAND_OUTPUT_COLUMNS } from '../src/cli/commands/service.js';
+
+function getAction(resourceName: string, actionName: string) {
+  const resource = lidarrResources.find(r => r.name === resourceName);
+  expect(resource).toBeDefined();
+  const action = resource!.actions.find(a => a.name === actionName);
+  expect(action).toBeDefined();
+  return action!;
+}
+
+describe('Lidarr command definitions', () => {
+  it('covers all expected resources', () => {
+    const names = lidarrResources.map(r => r.name).sort();
+    expect(names).toEqual([
+      'album',
+      'artist',
+      'blocklist',
+      'calendar',
+      'downloadclient',
+      'history',
+      'importlist',
+      'notification',
+      'profile',
+      'queue',
+      'rootfolder',
+      'system',
+      'tag',
+      'trackfile',
+      'wanted',
+    ]);
+  });
+
+  describe('artist resource', () => {
+    it('has all expected actions', () => {
+      const artist = lidarrResources.find(r => r.name === 'artist');
+      expect(artist!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'search',
+        'add',
+        'edit',
+        'refresh',
+        'manual-search',
+        'delete',
+      ]);
+    });
+
+    it('artist list has expected columns', () => {
+      const action = getAction('artist', 'list');
+      expect(action.columns).toEqual(['id', 'artistName', 'monitored', 'qualityProfileId']);
+    });
+
+    it('artist refresh uses command output columns', () => {
+      const action = getAction('artist', 'refresh');
+      expect(action.columns).toEqual(COMMAND_OUTPUT_COLUMNS);
+    });
+
+    it('artist manual-search uses command output columns', () => {
+      const action = getAction('artist', 'manual-search');
+      expect(action.columns).toEqual(COMMAND_OUTPUT_COLUMNS);
+    });
+
+    it('artist delete requires confirmation', () => {
+      const action = getAction('artist', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('artist edit has monitored, quality-profile-id, and tags args', () => {
+      const action = getAction('artist', 'edit');
+      const argNames = action.args!.map(a => a.name);
+      expect(argNames).toContain('id');
+      expect(argNames).toContain('monitored');
+      expect(argNames).toContain('quality-profile-id');
+      expect(argNames).toContain('tags');
+    });
+  });
+
+  describe('tag resource', () => {
+    it('has create, delete, list actions', () => {
+      const tag = lidarrResources.find(r => r.name === 'tag');
+      expect(tag!.actions.map(a => a.name)).toEqual(['create', 'delete', 'list']);
+    });
+
+    it('tag create requires label arg', () => {
+      const action = getAction('tag', 'create');
+      expect(action.args).toBeDefined();
+      expect(action.args![0].name).toBe('label');
+      expect(action.args![0].required).toBe(true);
+    });
+
+    it('tag delete requires confirmation', () => {
+      const action = getAction('tag', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('tag list has expected columns', () => {
+      const action = getAction('tag', 'list');
+      expect(action.columns).toEqual(['id', 'label']);
+    });
+  });
+
+  describe('notification resource', () => {
+    it('has list, get, add, edit, delete, test actions', () => {
+      const notification = lidarrResources.find(r => r.name === 'notification');
+      expect(notification!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'add',
+        'edit',
+        'delete',
+        'test',
+      ]);
+    });
+
+    it('notification list has expected columns', () => {
+      const action = getAction('notification', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation']);
+    });
+
+    it('notification delete requires confirmation', () => {
+      const action = getAction('notification', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('notification add requires file arg', () => {
+      const action = getAction('notification', 'add');
+      expect(action.args![0].name).toBe('file');
+      expect(action.args![0].required).toBe(true);
+    });
+
+    it('notification edit requires id and file args', () => {
+      const action = getAction('notification', 'edit');
+      const argNames = action.args!.map(a => a.name);
+      expect(argNames).toEqual(['id', 'file']);
+    });
+  });
+
+  describe('downloadclient resource', () => {
+    it('has list, get, add, edit, delete, test actions', () => {
+      const dc = lidarrResources.find(r => r.name === 'downloadclient');
+      expect(dc!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'add',
+        'edit',
+        'delete',
+        'test',
+      ]);
+    });
+
+    it('downloadclient list has expected columns', () => {
+      const action = getAction('downloadclient', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation', 'enable']);
+    });
+
+    it('downloadclient delete requires confirmation', () => {
+      const action = getAction('downloadclient', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('importlist resource', () => {
+    it('has list, get, add, edit, delete actions', () => {
+      const il = lidarrResources.find(r => r.name === 'importlist');
+      expect(il!.actions.map(a => a.name)).toEqual(['list', 'get', 'add', 'edit', 'delete']);
+    });
+
+    it('importlist list has expected columns', () => {
+      const action = getAction('importlist', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation', 'enable']);
+    });
+
+    it('importlist delete requires confirmation', () => {
+      const action = getAction('importlist', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('trackfile resource', () => {
+    it('has list, get, delete actions', () => {
+      const tf = lidarrResources.find(r => r.name === 'trackfile');
+      expect(tf!.actions.map(a => a.name)).toEqual(['list', 'get', 'delete']);
+    });
+
+    it('trackfile delete requires confirmation', () => {
+      const action = getAction('trackfile', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('other resources', () => {
+    it('queue has list, status, delete, grab actions', () => {
+      const queue = lidarrResources.find(r => r.name === 'queue');
+      expect(queue!.actions.map(a => a.name)).toEqual(['list', 'status', 'delete', 'grab']);
+    });
+
+    it('queue delete requires confirmation', () => {
+      const action = getAction('queue', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('blocklist has list and delete actions', () => {
+      const bl = lidarrResources.find(r => r.name === 'blocklist');
+      expect(bl!.actions.map(a => a.name)).toEqual(['list', 'delete']);
+    });
+
+    it('blocklist delete requires confirmation', () => {
+      const action = getAction('blocklist', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('wanted has missing and cutoff actions', () => {
+      const wanted = lidarrResources.find(r => r.name === 'wanted');
+      expect(wanted!.actions.map(a => a.name)).toEqual(['missing', 'cutoff']);
+    });
+
+    it('rootfolder has list, add, delete actions', () => {
+      const rf = lidarrResources.find(r => r.name === 'rootfolder');
+      expect(rf!.actions.map(a => a.name)).toEqual(['list', 'add', 'delete']);
+    });
+
+    it('rootfolder delete requires confirmation', () => {
+      const action = getAction('rootfolder', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('system has status and health actions', () => {
+      const system = lidarrResources.find(r => r.name === 'system');
+      expect(system!.actions.map(a => a.name)).toEqual(['status', 'health']);
+    });
+  });
+});

--- a/tests/cli-readarr-defs.test.ts
+++ b/tests/cli-readarr-defs.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'bun:test';
+import { resources as readarrResources } from '../src/cli/commands/readarr.js';
+import { COMMAND_OUTPUT_COLUMNS } from '../src/cli/commands/service.js';
+
+function getAction(resourceName: string, actionName: string) {
+  const resource = readarrResources.find(r => r.name === resourceName);
+  expect(resource).toBeDefined();
+  const action = resource!.actions.find(a => a.name === actionName);
+  expect(action).toBeDefined();
+  return action!;
+}
+
+describe('Readarr command definitions', () => {
+  it('covers all expected resources', () => {
+    const names = readarrResources.map(r => r.name).sort();
+    expect(names).toEqual([
+      'author',
+      'blocklist',
+      'book',
+      'bookfile',
+      'calendar',
+      'downloadclient',
+      'history',
+      'importlist',
+      'notification',
+      'profile',
+      'queue',
+      'rootfolder',
+      'system',
+      'tag',
+      'wanted',
+    ]);
+  });
+
+  describe('author resource', () => {
+    it('has all expected actions', () => {
+      const author = readarrResources.find(r => r.name === 'author');
+      expect(author!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'search',
+        'add',
+        'edit',
+        'refresh',
+        'manual-search',
+        'delete',
+      ]);
+    });
+
+    it('author list has expected columns', () => {
+      const action = getAction('author', 'list');
+      expect(action.columns).toEqual(['id', 'authorName', 'monitored', 'qualityProfileId']);
+    });
+
+    it('author refresh uses command output columns', () => {
+      const action = getAction('author', 'refresh');
+      expect(action.columns).toEqual(COMMAND_OUTPUT_COLUMNS);
+    });
+
+    it('author delete requires confirmation', () => {
+      const action = getAction('author', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+
+    it('author edit has monitored, quality-profile-id, and tags args', () => {
+      const action = getAction('author', 'edit');
+      const argNames = action.args!.map(a => a.name);
+      expect(argNames).toContain('id');
+      expect(argNames).toContain('monitored');
+      expect(argNames).toContain('quality-profile-id');
+      expect(argNames).toContain('tags');
+    });
+  });
+
+  describe('book resource', () => {
+    it('has list, get, search, add, edit, delete actions', () => {
+      const book = readarrResources.find(r => r.name === 'book');
+      expect(book!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'search',
+        'add',
+        'edit',
+        'delete',
+      ]);
+    });
+
+    it('book delete requires confirmation', () => {
+      const action = getAction('book', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('bookfile resource', () => {
+    it('has list, get, delete actions', () => {
+      const bf = readarrResources.find(r => r.name === 'bookfile');
+      expect(bf!.actions.map(a => a.name)).toEqual(['list', 'get', 'delete']);
+    });
+
+    it('bookfile delete requires confirmation', () => {
+      const action = getAction('bookfile', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('tag resource', () => {
+    it('has create, delete, list actions', () => {
+      const tag = readarrResources.find(r => r.name === 'tag');
+      expect(tag!.actions.map(a => a.name)).toEqual(['create', 'delete', 'list']);
+    });
+
+    it('tag create requires label arg', () => {
+      const action = getAction('tag', 'create');
+      expect(action.args![0].name).toBe('label');
+      expect(action.args![0].required).toBe(true);
+    });
+
+    it('tag delete requires confirmation', () => {
+      const action = getAction('tag', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('notification resource', () => {
+    it('has list, get, add, edit, delete, test actions', () => {
+      const notification = readarrResources.find(r => r.name === 'notification');
+      expect(notification!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'add',
+        'edit',
+        'delete',
+        'test',
+      ]);
+    });
+
+    it('notification list has expected columns', () => {
+      const action = getAction('notification', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation']);
+    });
+
+    it('notification delete requires confirmation', () => {
+      const action = getAction('notification', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('downloadclient resource', () => {
+    it('has list, get, add, edit, delete, test actions', () => {
+      const dc = readarrResources.find(r => r.name === 'downloadclient');
+      expect(dc!.actions.map(a => a.name)).toEqual([
+        'list',
+        'get',
+        'add',
+        'edit',
+        'delete',
+        'test',
+      ]);
+    });
+
+    it('downloadclient list has expected columns', () => {
+      const action = getAction('downloadclient', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation', 'enable']);
+    });
+
+    it('downloadclient delete requires confirmation', () => {
+      const action = getAction('downloadclient', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('importlist resource', () => {
+    it('has list, get, add, edit, delete actions', () => {
+      const il = readarrResources.find(r => r.name === 'importlist');
+      expect(il!.actions.map(a => a.name)).toEqual(['list', 'get', 'add', 'edit', 'delete']);
+    });
+
+    it('importlist list has expected columns', () => {
+      const action = getAction('importlist', 'list');
+      expect(action.columns).toEqual(['id', 'name', 'implementation', 'enable']);
+    });
+
+    it('importlist delete requires confirmation', () => {
+      const action = getAction('importlist', 'delete');
+      expect(action.confirmMessage).toBeDefined();
+    });
+  });
+
+  describe('other resources', () => {
+    it('queue has list, status, delete, grab actions', () => {
+      const queue = readarrResources.find(r => r.name === 'queue');
+      expect(queue!.actions.map(a => a.name)).toEqual(['list', 'status', 'delete', 'grab']);
+    });
+
+    it('blocklist has list and delete actions', () => {
+      const bl = readarrResources.find(r => r.name === 'blocklist');
+      expect(bl!.actions.map(a => a.name)).toEqual(['list', 'delete']);
+    });
+
+    it('wanted has missing and cutoff actions', () => {
+      const wanted = readarrResources.find(r => r.name === 'wanted');
+      expect(wanted!.actions.map(a => a.name)).toEqual(['missing', 'cutoff']);
+    });
+
+    it('rootfolder has list, add, delete actions', () => {
+      const rf = readarrResources.find(r => r.name === 'rootfolder');
+      expect(rf!.actions.map(a => a.name)).toEqual(['list', 'add', 'delete']);
+    });
+
+    it('system has status and health actions', () => {
+      const system = readarrResources.find(r => r.name === 'system');
+      expect(system!.actions.map(a => a.name)).toEqual(['status', 'health']);
+    });
+  });
+});

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -9,13 +9,11 @@ import {
   ReadarrClient,
   SonarrClient,
 } from '../src/index.js';
+import { SERVICE_CONFIGS } from './fixtures.js';
 
 describe('Client Unit Tests', () => {
   describe('RadarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:7878',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.radarr;
 
     it('should create client with valid config', () => {
       const client = new RadarrClient(validConfig);
@@ -182,10 +180,7 @@ describe('Client Unit Tests', () => {
   });
 
   describe('SonarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:8989',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.sonarr;
 
     it('should create client with valid config', () => {
       const client = new SonarrClient(validConfig);
@@ -265,10 +260,7 @@ describe('Client Unit Tests', () => {
   });
 
   describe('LidarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:8686',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.lidarr;
 
     it('should create client with valid config', () => {
       const client = new LidarrClient(validConfig);
@@ -345,10 +337,7 @@ describe('Client Unit Tests', () => {
   });
 
   describe('ReadarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:8787',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.readarr;
 
     it('should create client with valid config', () => {
       const client = new ReadarrClient(validConfig);
@@ -425,10 +414,7 @@ describe('Client Unit Tests', () => {
   });
 
   describe('ProwlarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:9696',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.prowlarr;
 
     it('should create client with valid config', () => {
       const client = new ProwlarrClient(validConfig);
@@ -446,10 +432,7 @@ describe('Client Unit Tests', () => {
   });
 
   describe('BazarrClient', () => {
-    const validConfig = {
-      baseUrl: 'http://localhost:6767',
-      apiKey: 'valid-api-key',
-    };
+    const validConfig = SERVICE_CONFIGS.bazarr;
 
     it('should create client with valid config', () => {
       const client = new BazarrClient(validConfig);
@@ -464,7 +447,7 @@ describe('Client Unit Tests', () => {
     it('should strip /api suffix when user includes it in base URL', () => {
       new BazarrClient({
         baseUrl: 'http://localhost:6767/api',
-        apiKey: 'valid-api-key',
+        apiKey: validConfig.apiKey,
       });
 
       expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767');
@@ -473,7 +456,95 @@ describe('Client Unit Tests', () => {
     it('should configure generated auth for Bazarr requests', () => {
       new BazarrClient(validConfig);
 
-      expect(bazarrApiClient.getConfig().auth).toBe('valid-api-key');
+      expect(bazarrApiClient.getConfig().auth).toBe(validConfig.apiKey);
+    });
+
+    it('should have all required methods', () => {
+      const client = new BazarrClient(validConfig);
+
+      // System
+      expect(typeof client.getSystemStatus).toBe('function');
+      expect(typeof client.getSystemHealth).toBe('function');
+      expect(typeof client.ping).toBe('function');
+      expect(typeof client.getSystemReleases).toBe('function');
+      expect(typeof client.getSystemAnnouncements).toBe('function');
+      expect(typeof client.dismissAnnouncement).toBe('function');
+      expect(typeof client.getSystemLogs).toBe('function');
+      expect(typeof client.rotateLogs).toBe('function');
+      expect(typeof client.getSystemTasks).toBe('function');
+      expect(typeof client.runSystemTask).toBe('function');
+
+      // Backup
+      expect(typeof client.getBackups).toBe('function');
+      expect(typeof client.createBackup).toBe('function');
+      expect(typeof client.restoreBackup).toBe('function');
+      expect(typeof client.deleteBackup).toBe('function');
+
+      // Jobs
+      expect(typeof client.getJobs).toBe('function');
+      expect(typeof client.manageJob).toBe('function');
+      expect(typeof client.deleteJob).toBe('function');
+      expect(typeof client.emptyJobQueue).toBe('function');
+
+      // Languages
+      expect(typeof client.getLanguages).toBe('function');
+      expect(typeof client.getLanguageProfiles).toBe('function');
+
+      // Series
+      expect(typeof client.getSeries).toBe('function');
+      expect(typeof client.updateSeriesLanguageProfile).toBe('function');
+      expect(typeof client.runSeriesAction).toBe('function');
+
+      // Episodes
+      expect(typeof client.getEpisodes).toBe('function');
+      expect(typeof client.getEpisodesWanted).toBe('function');
+      expect(typeof client.getEpisodesHistory).toBe('function');
+      expect(typeof client.downloadEpisodeSubtitles).toBe('function');
+      expect(typeof client.uploadEpisodeSubtitles).toBe('function');
+      expect(typeof client.deleteEpisodeSubtitles).toBe('function');
+
+      // Movies
+      expect(typeof client.getMovies).toBe('function');
+      expect(typeof client.updateMoviesLanguageProfile).toBe('function');
+      expect(typeof client.runMovieAction).toBe('function');
+      expect(typeof client.getMoviesWanted).toBe('function');
+      expect(typeof client.getMoviesHistory).toBe('function');
+      expect(typeof client.downloadMovieSubtitles).toBe('function');
+      expect(typeof client.uploadMovieSubtitles).toBe('function');
+      expect(typeof client.deleteMovieSubtitles).toBe('function');
+
+      // Providers
+      expect(typeof client.getProviders).toBe('function');
+      expect(typeof client.resetProviders).toBe('function');
+      expect(typeof client.searchEpisodeSubtitles).toBe('function');
+      expect(typeof client.searchMovieSubtitles).toBe('function');
+
+      // Blacklist
+      expect(typeof client.getEpisodesBlacklist).toBe('function');
+      expect(typeof client.addEpisodeToBlacklist).toBe('function');
+      expect(typeof client.removeEpisodeFromBlacklist).toBe('function');
+      expect(typeof client.getMoviesBlacklist).toBe('function');
+      expect(typeof client.addMovieToBlacklist).toBe('function');
+      expect(typeof client.removeMovieFromBlacklist).toBe('function');
+
+      // Badges / History / Search
+      expect(typeof client.getBadges).toBe('function');
+      expect(typeof client.getHistoryStats).toBe('function');
+      expect(typeof client.search).toBe('function');
+
+      // Filesystem
+      expect(typeof client.browseBazarrFs).toBe('function');
+      expect(typeof client.browseRadarrFs).toBe('function');
+      expect(typeof client.browseSonarrFs).toBe('function');
+
+      // Webhooks
+      expect(typeof client.testWebhook).toBe('function');
+      expect(typeof client.triggerPlexWebhook).toBe('function');
+      expect(typeof client.triggerRadarrWebhook).toBe('function');
+      expect(typeof client.triggerSonarrWebhook).toBe('function');
+
+      // Config
+      expect(typeof client.updateConfig).toBe('function');
     });
   });
 

--- a/tests/clients.test.ts
+++ b/tests/clients.test.ts
@@ -8,12 +8,10 @@ import {
   SeerrClient,
   SonarrClient,
 } from '../src/index.js';
+import { mockQbitConfig, mockServarrConfig } from './fixtures.js';
 
 describe('Tsarr Client Tests', () => {
-  const mockConfig = {
-    baseUrl: 'http://localhost:7878',
-    apiKey: 'test-key',
-  };
+  const mockConfig = mockServarrConfig;
 
   describe('Client Initialization', () => {
     it('should initialize RadarrClient', () => {
@@ -47,11 +45,7 @@ describe('Tsarr Client Tests', () => {
     });
 
     it('should initialize QBittorrentClient', () => {
-      const client = new QBittorrentClient({
-        baseUrl: 'http://localhost:8080',
-        username: 'admin',
-        password: 'adminadmin',
-      });
+      const client = new QBittorrentClient(mockQbitConfig);
       expect(client).toBeInstanceOf(QBittorrentClient);
     });
   });
@@ -150,11 +144,7 @@ describe('Tsarr Client Tests', () => {
 
   describe('QBittorrentClient Method Availability', () => {
     it('should have all required methods', () => {
-      const qbit = new QBittorrentClient({
-        baseUrl: 'http://localhost:8080',
-        username: 'admin',
-        password: 'admin',
-      });
+      const qbit = new QBittorrentClient(mockQbitConfig);
 
       expect(typeof qbit.getAppVersion).toBe('function');
       expect(typeof qbit.getApiVersion).toBe('function');

--- a/tests/config-commands.test.ts
+++ b/tests/config-commands.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getConfigValue, loadConfig, setConfigValue } from '../src/cli/config.js';
+
+describe('Config commands', () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'tsarr-config-test-'));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('setConfigValue / getConfigValue (local)', () => {
+    it('sets and gets a config value locally', () => {
+      // First create a valid config structure
+      writeFileSync(
+        join(tempDir, '.tsarr.json'),
+        JSON.stringify({
+          services: {
+            sonarr: [{ baseUrl: 'http://old:8989', apiKey: 'old-key' }],
+          },
+        })
+      );
+
+      setConfigValue('services.sonarr.baseUrl', 'http://localhost:8989', false);
+      const value = getConfigValue('services.sonarr.baseUrl');
+      expect(value).toBe('http://localhost:8989');
+    });
+
+    it('sets a value on an existing config and preserves other fields', () => {
+      writeFileSync(
+        join(tempDir, '.tsarr.json'),
+        JSON.stringify({
+          services: {
+            radarr: [{ baseUrl: 'http://localhost:7878', apiKey: 'my-key' }],
+          },
+        })
+      );
+
+      setConfigValue('services.radarr.apiKey', 'new-key', false);
+      expect(getConfigValue('services.radarr.apiKey')).toBe('new-key');
+      expect(getConfigValue('services.radarr.baseUrl')).toBe('http://localhost:7878');
+    });
+  });
+
+  describe('loadConfig', () => {
+    it('returns empty config when no files exist', () => {
+      const config = loadConfig();
+      expect(config).toBeDefined();
+      expect(config.services).toBeDefined();
+    });
+
+    it('loads local config from .tsarr.json', () => {
+      writeFileSync(
+        join(tempDir, '.tsarr.json'),
+        JSON.stringify({
+          services: {
+            radarr: [{ baseUrl: 'http://localhost:7878', apiKey: 'local-key' }],
+          },
+        })
+      );
+
+      const config = loadConfig();
+      expect(config.services.radarr).toBeDefined();
+      expect(config.services.radarr![0].baseUrl).toBe('http://localhost:7878');
+    });
+
+    it('loads single-object service config and normalizes to array', () => {
+      writeFileSync(
+        join(tempDir, '.tsarr.json'),
+        JSON.stringify({
+          services: {
+            radarr: { baseUrl: 'http://localhost:7878', apiKey: 'my-key' },
+          },
+        })
+      );
+
+      const config = loadConfig();
+      expect(Array.isArray(config.services.radarr)).toBe(true);
+      expect(config.services.radarr![0].baseUrl).toBe('http://localhost:7878');
+    });
+
+    it('returns undefined for non-existent config keys', () => {
+      const value = getConfigValue('services.nonexistent.baseUrl');
+      expect(value).toBeUndefined();
+    });
+  });
+
+  describe('config show redaction logic', () => {
+    it('redacts apiKey and password', () => {
+      const config = {
+        services: {
+          radarr: [{ baseUrl: 'http://localhost:7878', apiKey: 'secret-key' }],
+          qbittorrent: [
+            { baseUrl: 'http://localhost:8080', username: 'admin', password: 'secret-pass' },
+          ],
+        },
+      };
+
+      const redacted = JSON.parse(JSON.stringify(config));
+      for (const instances of Object.values(redacted.services) as any[]) {
+        if (Array.isArray(instances)) {
+          for (const svc of instances) {
+            if (svc?.apiKey) svc.apiKey = '*****';
+            if (svc?.password) svc.password = '*****';
+          }
+        }
+      }
+
+      expect(redacted.services.radarr[0].apiKey).toBe('*****');
+      expect(redacted.services.qbittorrent[0].password).toBe('*****');
+      expect(redacted.services.radarr[0].baseUrl).toBe('http://localhost:7878');
+      expect(redacted.services.qbittorrent[0].username).toBe('admin');
+    });
+  });
+
+  describe('config set display redaction', () => {
+    it('sensitive key patterns are detected', () => {
+      const sensitiveKeys = [
+        'services.radarr.apiKey',
+        'services.qbittorrent.password',
+        'services.seerr.token',
+        'services.test.secret',
+      ];
+
+      for (const key of sensitiveKeys) {
+        const shouldRedact = /\b(apiKey|apikey|token|secret|password)\b/i.test(key);
+        expect(shouldRedact).toBe(true);
+      }
+    });
+
+    it('non-sensitive key patterns are not redacted', () => {
+      const safeKeys = ['services.radarr.baseUrl', 'defaults.format', 'services.radarr.name'];
+      for (const key of safeKeys) {
+        const shouldRedact = /\b(apiKey|apikey|token|secret|password)\b/i.test(key);
+        expect(shouldRedact).toBe(false);
+      }
+    });
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared test fixtures and mock data.
+ * Consolidates duplicated mock configs from clients.test.ts and clients-unit.test.ts.
+ */
+
+export const mockServarrConfig = {
+  baseUrl: 'http://localhost:7878',
+  apiKey: 'test-api-key',
+};
+
+export const mockQbitConfig = {
+  baseUrl: 'http://localhost:8080',
+  username: 'admin',
+  password: 'adminadmin',
+};
+
+export const SERVICE_CONFIGS: Record<string, { baseUrl: string; apiKey: string }> = {
+  radarr: { baseUrl: 'http://localhost:7878', apiKey: 'test-api-key' },
+  sonarr: { baseUrl: 'http://localhost:8989', apiKey: 'test-api-key' },
+  lidarr: { baseUrl: 'http://localhost:8686', apiKey: 'test-api-key' },
+  readarr: { baseUrl: 'http://localhost:8787', apiKey: 'test-api-key' },
+  prowlarr: { baseUrl: 'http://localhost:9696', apiKey: 'test-api-key' },
+  bazarr: { baseUrl: 'http://localhost:6767', apiKey: 'test-api-key' },
+  seerr: { baseUrl: 'http://localhost:5055', apiKey: 'test-api-key' },
+};


### PR DESCRIPTION
## Summary
Closes #176

- Add CLI command definition tests for Bazarr, Lidarr, and Readarr (covering notification, downloadclient, importlist, tag create/delete, queue, blocklist, wanted, rootfolder, and file resources)
- Add shell completions tests for bash, zsh, and fish output
- Add config commands tests for set/get, loadConfig, and redaction logic
- Add BazarrClient method availability tests (45+ methods)
- Extract shared mock fixtures to `tests/fixtures.ts`, eliminating duplication across `clients.test.ts` and `clients-unit.test.ts`

## Test plan
- [x] All 249 tests pass (`bun test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)