### PR TITLE
feat(core): add resilient fetch with timeout and retry across all clients

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/clients/base.ts
+++ b/src/clients/base.ts
@@ -72,17 +72,25 @@ export interface ServarrOps {
   updateUiConfig: ApiCall;
 }
 
+interface RawClient {
+  setConfig(config: Record<string, unknown>): unknown;
+}
+
 export abstract class ServarrBaseClient {
   protected clientConfig: ReturnType<typeof createServarrClient>;
+  protected readonly rawClient: RawClient;
 
   protected abstract readonly ops: ServarrOps;
 
-  constructor(config: ServarrClientConfig) {
+  constructor(config: ServarrClientConfig, rawClient: RawClient) {
+    this.rawClient = rawClient;
     this.clientConfig = createServarrClient(config);
     this.configureRawClient();
   }
 
-  protected abstract configureRawClient(): void;
+  protected configureRawClient(): void {
+    this.rawClient.setConfig(this.getClientConfig());
+  }
 
   protected getClientConfig() {
     return {

--- a/src/clients/base.ts
+++ b/src/clients/base.ts
@@ -88,7 +88,7 @@ export abstract class ServarrBaseClient {
     return {
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+      fetch: this.clientConfig.getFetch(),
     };
   }
 

--- a/src/clients/bazarr.ts
+++ b/src/clients/bazarr.ts
@@ -40,7 +40,7 @@ export class BazarrClient {
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+      fetch: this.clientConfig.getFetch(),
     });
   }
 
@@ -700,7 +700,7 @@ export class BazarrClient {
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+      fetch: this.clientConfig.getFetch(),
     });
 
     return this.clientConfig.config;

--- a/src/clients/lidarr.ts
+++ b/src/clients/lidarr.ts
@@ -1,4 +1,5 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import type { ServarrClientConfig } from '../core/types';
 import { client as lidarrClient } from '../generated/lidarr/client.gen';
 import * as LidarrApi from '../generated/lidarr/index';
 import type {
@@ -98,8 +99,8 @@ export class LidarrClient extends ServarrBaseClient {
     updateUiConfig: LidarrApi.putApiV1ConfigUiById,
   };
 
-  protected configureRawClient(): void {
-    lidarrClient.setConfig(this.getClientConfig());
+  constructor(config: ServarrClientConfig) {
+    super(config, lidarrClient);
   }
 
   // Artist APIs

--- a/src/clients/prowlarr.ts
+++ b/src/clients/prowlarr.ts
@@ -1,4 +1,5 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import type { ServarrClientConfig } from '../core/types';
 import { client as prowlarrClient } from '../generated/prowlarr/client.gen';
 import * as ProwlarrApi from '../generated/prowlarr/index';
 import type {
@@ -89,8 +90,8 @@ export class ProwlarrClient extends ServarrBaseClient {
     updateUiConfig: ProwlarrApi.putApiV1ConfigUiById,
   };
 
-  protected configureRawClient(): void {
-    prowlarrClient.setConfig(this.getClientConfig());
+  constructor(config: ServarrClientConfig) {
+    super(config, prowlarrClient);
   }
 
   // Prowlarr-specific APIs

--- a/src/clients/qbittorrent.ts
+++ b/src/clients/qbittorrent.ts
@@ -1,4 +1,5 @@
 import { ConnectionError } from '../core/errors';
+import { createResilientFetch } from '../core/fetch';
 import type { QBittorrentClientConfig } from '../core/types';
 import { client as qbittorrentClient } from '../generated/qbittorrent/client.gen';
 import * as QBittorrentApi from '../generated/qbittorrent/index';
@@ -33,7 +34,7 @@ export class QBittorrentClient {
   private username: string;
   private password: string;
   private sid: string | null = null;
-  private timeoutMs: number;
+  private fetch: typeof globalThis.fetch;
 
   constructor(config: QBittorrentClientConfig) {
     if (!config.baseUrl) {
@@ -43,12 +44,15 @@ export class QBittorrentClient {
     this.baseUrl = config.baseUrl.replace(/\/$/, '');
     this.username = config.username;
     this.password = config.password;
-    this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.fetch = createResilientFetch({
+      timeout: config.timeout ?? DEFAULT_TIMEOUT_MS,
+      retry: config.retry,
+    });
 
     qbittorrentClient.setConfig({
       baseUrl: `${this.baseUrl}/api/v2`,
       auth: () => this.ensureAuth(),
-      signal: AbortSignal.timeout(this.timeoutMs),
+      fetch: this.fetch,
     });
   }
 
@@ -60,7 +64,7 @@ export class QBittorrentClient {
   }
 
   private async login(): Promise<void> {
-    const response = await fetch(`${this.baseUrl}/api/v2/auth/login`, {
+    const response = await this.fetch(`${this.baseUrl}/api/v2/auth/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -70,7 +74,6 @@ export class QBittorrentClient {
         username: this.username,
         password: this.password,
       }),
-      signal: AbortSignal.timeout(this.timeoutMs),
     });
 
     if (!response.ok) {

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -1,4 +1,5 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import type { ServarrClientConfig } from '../core/types';
 import { client as radarrClient } from '../generated/radarr/client.gen';
 import * as RadarrApi from '../generated/radarr/index';
 import type {
@@ -84,8 +85,8 @@ export class RadarrClient extends ServarrBaseClient {
     updateUiConfig: RadarrApi.putApiV3ConfigUiById,
   };
 
-  protected configureRawClient(): void {
-    radarrClient.setConfig(this.getClientConfig());
+  constructor(config: ServarrClientConfig) {
+    super(config, radarrClient);
   }
 
   // Movie APIs

--- a/src/clients/readarr.ts
+++ b/src/clients/readarr.ts
@@ -1,4 +1,5 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import type { ServarrClientConfig } from '../core/types';
 import { client as readarrClient } from '../generated/readarr/client.gen';
 import * as ReadarrApi from '../generated/readarr/index';
 import type {
@@ -98,8 +99,8 @@ export class ReadarrClient extends ServarrBaseClient {
     updateUiConfig: ReadarrApi.putApiV1ConfigUiById,
   };
 
-  protected configureRawClient(): void {
-    readarrClient.setConfig(this.getClientConfig());
+  constructor(config: ServarrClientConfig) {
+    super(config, readarrClient);
   }
 
   // Author APIs

--- a/src/clients/seerr.ts
+++ b/src/clients/seerr.ts
@@ -40,7 +40,7 @@ export class SeerrClient {
         'X-Api-Key': this.clientConfig.config.apiKey,
         ...(this.clientConfig.config.headers ?? {}),
       },
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+      fetch: this.clientConfig.getFetch(),
     });
   }
 
@@ -140,7 +140,7 @@ export class SeerrClient {
         'X-Api-Key': this.clientConfig.config.apiKey,
         ...(this.clientConfig.config.headers ?? {}),
       },
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+      fetch: this.clientConfig.getFetch(),
     });
 
     return this.clientConfig.config;

--- a/src/clients/sonarr.ts
+++ b/src/clients/sonarr.ts
@@ -1,4 +1,5 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import type { ServarrClientConfig } from '../core/types';
 import { client as sonarrClient } from '../generated/sonarr/client.gen';
 import * as SonarrApi from '../generated/sonarr/index';
 import type {
@@ -98,8 +99,8 @@ export class SonarrClient extends ServarrBaseClient {
     updateUiConfig: SonarrApi.putApiV3ConfigUiById,
   };
 
-  protected configureRawClient(): void {
-    sonarrClient.setConfig(this.getClientConfig());
+  constructor(config: ServarrClientConfig) {
+    super(config, sonarrClient);
   }
 
   // Override since Sonarr doesn't have generated system status endpoints

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,4 +1,5 @@
 import { ApiKeyError, ConnectionError } from './errors';
+import { createResilientFetch } from './fetch';
 import type { ServarrClientConfig } from './types';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -19,6 +20,11 @@ export function createServarrClient(config: ServarrClientConfig) {
 
   const timeoutMs = validatedConfig.timeout ?? DEFAULT_TIMEOUT_MS;
 
+  const resilientFetch = createResilientFetch({
+    timeout: timeoutMs,
+    retry: validatedConfig.retry,
+  });
+
   return {
     config: validatedConfig,
     getHeaders: () => ({
@@ -28,6 +34,7 @@ export function createServarrClient(config: ServarrClientConfig) {
     }),
     getBaseUrl: () => validatedConfig.baseUrl,
     getTimeout: () => timeoutMs,
+    getFetch: () => resilientFetch,
   };
 }
 

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -1,0 +1,130 @@
+import { ConnectionError } from './errors';
+
+export interface RetryOptions {
+  /** Maximum number of retry attempts for transient failures (default: 3) */
+  maxRetries?: number;
+  /** Initial delay in ms before the first retry (default: 1000) */
+  initialDelayMs?: number;
+  /** Maximum delay in ms between retries (default: 10000) */
+  maxDelayMs?: number;
+}
+
+export interface ResilientFetchOptions {
+  /** Request timeout in milliseconds (default: 30000) */
+  timeout?: number;
+  /** Retry configuration for transient failures */
+  retry?: RetryOptions;
+}
+
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_DELAY = 1_000;
+const DEFAULT_MAX_DELAY = 10_000;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504]);
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return false;
+  }
+  if (error instanceof TypeError) {
+    // Network errors from fetch (e.g. DNS failure, connection refused)
+    return true;
+  }
+  return false;
+}
+
+function getRetryDelay(attempt: number, initialDelayMs: number, maxDelayMs: number): number {
+  const delay = initialDelayMs * 2 ** attempt;
+  const jitter = delay * 0.2 * Math.random();
+  return Math.min(delay + jitter, maxDelayMs);
+}
+
+/**
+ * Creates a fetch function with timeout and retry support.
+ *
+ * - Timeout uses AbortController to cancel requests that exceed the limit.
+ * - Retry uses exponential backoff with jitter for transient failures
+ *   (network errors and 408/429/502/503/504 status codes).
+ */
+export function createResilientFetch(options: ResilientFetchOptions = {}): typeof fetch {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+  const maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const initialDelayMs = options.retry?.initialDelayMs ?? DEFAULT_INITIAL_DELAY;
+  const maxDelayMs = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY;
+
+  const resilientFetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      // Merge abort signals: respect caller's signal and our timeout
+      const callerSignal = init?.signal;
+      if (callerSignal?.aborted) {
+        clearTimeout(timeoutId);
+        throw callerSignal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+      }
+
+      const onCallerAbort = () => controller.abort(callerSignal!.reason);
+      callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+
+      try {
+        const response = await globalThis.fetch(input, {
+          ...init,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+        callerSignal?.removeEventListener('abort', onCallerAbort);
+
+        if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < maxRetries) {
+          lastError = new ConnectionError(`Request failed with status ${response.status}`);
+          const delay = getRetryDelay(attempt, initialDelayMs, maxDelayMs);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+
+        return response;
+      } catch (error) {
+        clearTimeout(timeoutId);
+        callerSignal?.removeEventListener('abort', onCallerAbort);
+
+        // If the caller aborted, don't retry
+        if (callerSignal?.aborted) {
+          throw callerSignal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+        }
+
+        // Timeout: wrap as ConnectionError
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          lastError = new ConnectionError(`Request timed out after ${timeout}ms`);
+          if (attempt < maxRetries) {
+            const delay = getRetryDelay(attempt, initialDelayMs, maxDelayMs);
+            await new Promise(resolve => setTimeout(resolve, delay));
+            continue;
+          }
+          throw lastError;
+        }
+
+        if (isRetryable(error) && attempt < maxRetries) {
+          lastError = error;
+          const delay = getRetryDelay(attempt, initialDelayMs, maxDelayMs);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw lastError;
+  };
+
+  return Object.assign(resilientFetch, {
+    preconnect: globalThis.fetch.preconnect?.bind(globalThis.fetch),
+  }) as typeof fetch;
+}

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -12,7 +12,7 @@ export interface RetryOptions {
 export interface ResilientFetchOptions {
   /** Request timeout in milliseconds (default: 30000) */
   timeout?: number;
-  /** Retry configuration for transient failures */
+  /** Retry configuration for transient failures. Omit to disable retries. */
   retry?: RetryOptions;
 }
 
@@ -49,7 +49,7 @@ function getRetryDelay(attempt: number, initialDelayMs: number, maxDelayMs: numb
  */
 export function createResilientFetch(options: ResilientFetchOptions = {}): typeof fetch {
   const timeout = options.timeout ?? DEFAULT_TIMEOUT;
-  const maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const maxRetries = options.retry ? options.retry.maxRetries ?? DEFAULT_MAX_RETRIES : 0;
   const initialDelayMs = options.retry?.initialDelayMs ?? DEFAULT_INITIAL_DELAY;
   const maxDelayMs = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY;
 
@@ -58,6 +58,7 @@ export function createResilientFetch(options: ResilientFetchOptions = {}): typeo
     init?: RequestInit
   ): Promise<Response> => {
     let lastError: unknown;
+    const template = createRequestTemplate(input, init);
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const controller = new AbortController();
@@ -74,10 +75,9 @@ export function createResilientFetch(options: ResilientFetchOptions = {}): typeo
       callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
 
       try {
-        const response = await globalThis.fetch(input, {
-          ...init,
-          signal: controller.signal,
-        });
+        const response = await globalThis.fetch(
+          new Request(template.clone(), { signal: controller.signal })
+        );
 
         clearTimeout(timeoutId);
         callerSignal?.removeEventListener('abort', onCallerAbort);
@@ -127,4 +127,14 @@ export function createResilientFetch(options: ResilientFetchOptions = {}): typeo
   return Object.assign(resilientFetch, {
     preconnect: globalThis.fetch.preconnect?.bind(globalThis.fetch),
   }) as typeof fetch;
+}
+
+function createRequestTemplate(input: RequestInfo | URL, init?: RequestInit): Request {
+  const { signal: _signal, ...requestInit } = init ?? {};
+
+  if (input instanceof Request) {
+    return init ? new Request(input.clone(), requestInit) : input.clone();
+  }
+
+  return new Request(input, requestInit);
 }

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -49,7 +49,7 @@ function getRetryDelay(attempt: number, initialDelayMs: number, maxDelayMs: numb
  */
 export function createResilientFetch(options: ResilientFetchOptions = {}): typeof fetch {
   const timeout = options.timeout ?? DEFAULT_TIMEOUT;
-  const maxRetries = options.retry ? options.retry.maxRetries ?? DEFAULT_MAX_RETRIES : 0;
+  const maxRetries = options.retry ? (options.retry.maxRetries ?? DEFAULT_MAX_RETRIES) : 0;
   const initialDelayMs = options.retry?.initialDelayMs ?? DEFAULT_INITIAL_DELAY;
   const maxDelayMs = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from './client';
 export * from './errors';
+export * from './fetch';
 export * from './types';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,12 @@
+import type { RetryOptions } from './fetch';
+
 export interface ServarrClientConfig {
   baseUrl: string;
   apiKey: string;
+  /** Request timeout in milliseconds (default: 30000) */
   timeout?: number;
+  /** Retry configuration for transient failures */
+  retry?: RetryOptions;
   headers?: Record<string, string>;
 }
 
@@ -9,5 +14,8 @@ export interface QBittorrentClientConfig {
   baseUrl: string;
   username: string;
   password: string;
+  /** Request timeout in milliseconds (default: 30000) */
   timeout?: number;
+  /** Retry configuration for transient failures */
+  retry?: RetryOptions;
 }

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { ConnectionError } from '../src/core/errors.js';
+import { createResilientFetch } from '../src/core/fetch.js';
+
+describe('createResilientFetch', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('timeout', () => {
+    it('should abort requests that exceed the timeout', async () => {
+      globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+        // Simulate a slow request that respects abort
+        return new Promise((_resolve, reject) => {
+          const onAbort = () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          if (init?.signal?.aborted) {
+            onAbort();
+            return;
+          }
+          init?.signal?.addEventListener('abort', onAbort);
+        });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        timeout: 50,
+        retry: { maxRetries: 0 },
+      });
+
+      await expect(resilientFetch('http://example.com')).rejects.toBeInstanceOf(ConnectionError);
+      await expect(resilientFetch('http://example.com')).rejects.toHaveProperty(
+        'message',
+        'Request timed out after 50ms'
+      );
+    });
+
+    it('should use the default timeout when none is specified', () => {
+      const resilientFetch = createResilientFetch();
+      expect(resilientFetch).toBeFunction();
+    });
+
+    it('should succeed if the request completes within the timeout', async () => {
+      globalThis.fetch = (async () => {
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({ timeout: 5000 });
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('retry', () => {
+    it('should retry on 503 status and eventually succeed', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        if (attempt < 3) {
+          return new Response('Service Unavailable', { status: 503 });
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 3, initialDelayMs: 10, maxDelayMs: 50 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(200);
+      expect(attempt).toBe(3);
+    });
+
+    it('should retry on 429 status', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        if (attempt === 1) {
+          return new Response('Too Many Requests', { status: 429 });
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 2, initialDelayMs: 10 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(200);
+      expect(attempt).toBe(2);
+    });
+
+    it('should retry on network errors (TypeError)', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        if (attempt < 2) {
+          throw new TypeError('fetch failed');
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 2, initialDelayMs: 10 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(200);
+      expect(attempt).toBe(2);
+    });
+
+    it('should not retry on 4xx errors (except 408, 429)', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        return new Response('Not Found', { status: 404 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 3, initialDelayMs: 10 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(404);
+      expect(attempt).toBe(1);
+    });
+
+    it('should return the last retryable response after exhausting retries', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        return new Response('Bad Gateway', { status: 502 });
+      }) as typeof fetch;
+
+      // maxRetries: 2 means initial + 2 retries = 3 total attempts
+      // But the 4th attempt (index 3) returns the response since attempt >= maxRetries
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 2, initialDelayMs: 10 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      // After exhausting retries, the last attempt returns the 502 response
+      expect(response.status).toBe(502);
+      expect(attempt).toBe(3);
+    });
+
+    it('should respect maxRetries: 0 and not retry', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async () => {
+        attempt++;
+        return new Response('Bad Gateway', { status: 502 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 0 },
+      });
+
+      const response = await resilientFetch('http://example.com');
+      expect(response.status).toBe(502);
+      expect(attempt).toBe(1);
+    });
+  });
+
+  describe('caller abort signal', () => {
+    it('should respect caller abort signal', async () => {
+      globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          const onAbort = () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          if (init?.signal?.aborted) {
+            onAbort();
+            return;
+          }
+          init?.signal?.addEventListener('abort', onAbort);
+        });
+      }) as typeof fetch;
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 0 },
+      });
+
+      await expect(
+        resilientFetch('http://example.com', { signal: controller.signal })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('integration with createServarrClient', () => {
+    it('should produce a fetch function', () => {
+      const resilientFetch = createResilientFetch({
+        timeout: 5000,
+        retry: { maxRetries: 2 },
+      });
+
+      expect(resilientFetch).toBeFunction();
+    });
+  });
+});

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -13,18 +13,23 @@ describe('createResilientFetch', () => {
     globalThis.fetch = originalFetch;
   });
 
+  function getSignal(input: RequestInfo | URL, init?: RequestInit) {
+    return init?.signal ?? (input instanceof Request ? input.signal : undefined);
+  }
+
   describe('timeout', () => {
     it('should abort requests that exceed the timeout', async () => {
-      globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
         // Simulate a slow request that respects abort
         return new Promise((_resolve, reject) => {
+          const signal = getSignal(input, init);
           const onAbort = () =>
             reject(new DOMException('The operation was aborted.', 'AbortError'));
-          if (init?.signal?.aborted) {
+          if (signal?.aborted) {
             onAbort();
             return;
           }
-          init?.signal?.addEventListener('abort', onAbort);
+          signal?.addEventListener('abort', onAbort, { once: true });
         });
       }) as typeof fetch;
 
@@ -43,6 +48,28 @@ describe('createResilientFetch', () => {
     it('should use the default timeout when none is specified', () => {
       const resilientFetch = createResilientFetch();
       expect(resilientFetch).toBeFunction();
+    });
+
+    it('should not retry timeouts unless retry is explicitly configured', async () => {
+      let attempt = 0;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        attempt++;
+        return new Promise((_resolve, reject) => {
+          const signal = getSignal(input, init);
+          const onAbort = () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          if (signal?.aborted) {
+            onAbort();
+            return;
+          }
+          signal?.addEventListener('abort', onAbort, { once: true });
+        });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({ timeout: 50 });
+
+      await expect(resilientFetch('http://example.com')).rejects.toBeInstanceOf(ConnectionError);
+      expect(attempt).toBe(1);
     });
 
     it('should succeed if the request completes within the timeout', async () => {
@@ -74,6 +101,38 @@ describe('createResilientFetch', () => {
       const response = await resilientFetch('http://example.com');
       expect(response.status).toBe(200);
       expect(attempt).toBe(3);
+    });
+
+    it('should retry request objects with bodies using a fresh clone each attempt', async () => {
+      const bodies: string[] = [];
+      let attempt = 0;
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        attempt++;
+        const request = input as Request;
+        bodies.push(await request.text());
+        if (attempt === 1) {
+          return new Response('Service Unavailable', { status: 503 });
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const resilientFetch = createResilientFetch({
+        retry: { maxRetries: 1, initialDelayMs: 10, maxDelayMs: 10 },
+      });
+
+      const request = new Request('http://example.com', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'test' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const response = await resilientFetch(request);
+      expect(response.status).toBe(200);
+      expect(attempt).toBe(2);
+      expect(bodies).toEqual([
+        JSON.stringify({ title: 'test' }),
+        JSON.stringify({ title: 'test' }),
+      ]);
     });
 
     it('should retry on 429 status', async () => {
@@ -168,15 +227,16 @@ describe('createResilientFetch', () => {
 
   describe('caller abort signal', () => {
     it('should respect caller abort signal', async () => {
-      globalThis.fetch = (async (_input: any, init?: RequestInit) => {
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
         return new Promise((_resolve, reject) => {
+          const signal = getSignal(input, init);
           const onAbort = () =>
             reject(new DOMException('The operation was aborted.', 'AbortError'));
-          if (init?.signal?.aborted) {
+          if (signal?.aborted) {
             onAbort();
             return;
           }
-          init?.signal?.addEventListener('abort', onAbort);
+          signal?.addEventListener('abort', onAbort, { once: true });
         });
       }) as typeof fetch;
 


### PR DESCRIPTION
## Summary
- Adds `createResilientFetch()` in `src/core/fetch.ts` — a fetch wrapper with configurable timeout (default 30s) and exponential backoff retry for transient failures (408, 429, 502, 503, 504, network errors)
- Wires the resilient fetch into all 8 service clients (Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, Seerr, qBittorrent) via the generated client's `fetch` config option
- The existing `timeout` and new `retry` config options on `ServarrClientConfig` / `QBittorrentClientConfig` are now actually used

Closes #179

## Test plan
- [x] 11 new unit tests covering timeout, retry on 5xx/429, retry on network errors, no-retry on 4xx, retry exhaustion, abort signal passthrough
- [x] All 169 existing tests pass
- [x] TypeScript type checks pass
- [x] Biome lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resilient fetch with configurable timeout and retry (automatic retries for transient network/errors).
  * Client configuration now exposes the resilient fetch and retry options for improved request reliability.

* **Bug Fixes / Improvements**
  * Clients switched to the standardized fetch mechanism for consistent timeout and retry behavior.

* **Tests**
  * Added comprehensive tests validating timeout, retry, abort, and body-cloning behavior of the resilient fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->