### PR TITLE
fix(core): add default request timeout, HTTP warning, and debug logging

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -85,10 +85,11 @@ async function testConnection(service: string, serviceConfig: ServiceConfig): Pr
         );
       }
     }
-  } catch {
+  } catch (error) {
     consola.warn(
       `Could not connect to ${service}${serviceConfig.name ? ` (${serviceConfig.name})` : ''} — config saved anyway.`
     );
+    consola.debug('Connection test error:', error);
   }
 }
 

--- a/src/clients/base.ts
+++ b/src/clients/base.ts
@@ -84,6 +84,14 @@ export abstract class ServarrBaseClient {
 
   protected abstract configureRawClient(): void;
 
+  protected getClientConfig() {
+    return {
+      baseUrl: this.clientConfig.getBaseUrl(),
+      headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
+    };
+  }
+
   // System APIs
 
   async getSystemStatus() {

--- a/src/clients/bazarr.ts
+++ b/src/clients/bazarr.ts
@@ -40,6 +40,7 @@ export class BazarrClient {
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 
@@ -699,6 +700,7 @@ export class BazarrClient {
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
 
     return this.clientConfig.config;

--- a/src/clients/lidarr.ts
+++ b/src/clients/lidarr.ts
@@ -102,6 +102,7 @@ export class LidarrClient extends ServarrBaseClient {
     lidarrClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 

--- a/src/clients/lidarr.ts
+++ b/src/clients/lidarr.ts
@@ -99,11 +99,7 @@ export class LidarrClient extends ServarrBaseClient {
   };
 
   protected configureRawClient(): void {
-    lidarrClient.setConfig({
-      baseUrl: this.clientConfig.getBaseUrl(),
-      headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
-    });
+    lidarrClient.setConfig(this.getClientConfig());
   }
 
   // Artist APIs

--- a/src/clients/prowlarr.ts
+++ b/src/clients/prowlarr.ts
@@ -93,6 +93,7 @@ export class ProwlarrClient extends ServarrBaseClient {
     prowlarrClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 

--- a/src/clients/prowlarr.ts
+++ b/src/clients/prowlarr.ts
@@ -90,11 +90,7 @@ export class ProwlarrClient extends ServarrBaseClient {
   };
 
   protected configureRawClient(): void {
-    prowlarrClient.setConfig({
-      baseUrl: this.clientConfig.getBaseUrl(),
-      headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
-    });
+    prowlarrClient.setConfig(this.getClientConfig());
   }
 
   // Prowlarr-specific APIs

--- a/src/clients/qbittorrent.ts
+++ b/src/clients/qbittorrent.ts
@@ -26,11 +26,14 @@ type TorrentFilter = NonNullable<TorrentsInfoPostData['body']['filter']>;
  * const torrents = await qbit.getTorrents();
  * ```
  */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export class QBittorrentClient {
   private baseUrl: string;
   private username: string;
   private password: string;
   private sid: string | null = null;
+  private timeoutMs: number;
 
   constructor(config: QBittorrentClientConfig) {
     if (!config.baseUrl) {
@@ -40,10 +43,12 @@ export class QBittorrentClient {
     this.baseUrl = config.baseUrl.replace(/\/$/, '');
     this.username = config.username;
     this.password = config.password;
+    this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS;
 
     qbittorrentClient.setConfig({
       baseUrl: `${this.baseUrl}/api/v2`,
       auth: () => this.ensureAuth(),
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
   }
 
@@ -65,6 +70,7 @@ export class QBittorrentClient {
         username: this.username,
         password: this.password,
       }),
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
 
     if (!response.ok) {

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -85,11 +85,7 @@ export class RadarrClient extends ServarrBaseClient {
   };
 
   protected configureRawClient(): void {
-    radarrClient.setConfig({
-      baseUrl: this.clientConfig.getBaseUrl(),
-      headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
-    });
+    radarrClient.setConfig(this.getClientConfig());
   }
 
   // Movie APIs

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -88,6 +88,7 @@ export class RadarrClient extends ServarrBaseClient {
     radarrClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 

--- a/src/clients/readarr.ts
+++ b/src/clients/readarr.ts
@@ -99,11 +99,7 @@ export class ReadarrClient extends ServarrBaseClient {
   };
 
   protected configureRawClient(): void {
-    readarrClient.setConfig({
-      baseUrl: this.clientConfig.getBaseUrl(),
-      headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
-    });
+    readarrClient.setConfig(this.getClientConfig());
   }
 
   // Author APIs

--- a/src/clients/readarr.ts
+++ b/src/clients/readarr.ts
@@ -102,6 +102,7 @@ export class ReadarrClient extends ServarrBaseClient {
     readarrClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 

--- a/src/clients/seerr.ts
+++ b/src/clients/seerr.ts
@@ -40,6 +40,7 @@ export class SeerrClient {
         'X-Api-Key': this.clientConfig.config.apiKey,
         ...(this.clientConfig.config.headers ?? {}),
       },
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 
@@ -139,6 +140,7 @@ export class SeerrClient {
         'X-Api-Key': this.clientConfig.config.apiKey,
         ...(this.clientConfig.config.headers ?? {}),
       },
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
 
     return this.clientConfig.config;

--- a/src/clients/sonarr.ts
+++ b/src/clients/sonarr.ts
@@ -102,6 +102,7 @@ export class SonarrClient extends ServarrBaseClient {
     sonarrClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: this.clientConfig.getHeaders(),
+      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
     });
   }
 

--- a/src/clients/sonarr.ts
+++ b/src/clients/sonarr.ts
@@ -99,11 +99,7 @@ export class SonarrClient extends ServarrBaseClient {
   };
 
   protected configureRawClient(): void {
-    sonarrClient.setConfig({
-      baseUrl: this.clientConfig.getBaseUrl(),
-      headers: this.clientConfig.getHeaders(),
-      signal: AbortSignal.timeout(this.clientConfig.getTimeout()),
-    });
+    sonarrClient.setConfig(this.getClientConfig());
   }
 
   // Override since Sonarr doesn't have generated system status endpoints

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,6 +1,8 @@
 import { ApiKeyError, ConnectionError } from './errors';
 import type { ServarrClientConfig } from './types';
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export function createServarrClient(config: ServarrClientConfig) {
   if (!config.apiKey) {
     throw new ApiKeyError();
@@ -15,6 +17,8 @@ export function createServarrClient(config: ServarrClientConfig) {
     baseUrl: config.baseUrl.replace(/\/$/, ''),
   };
 
+  const timeoutMs = validatedConfig.timeout ?? DEFAULT_TIMEOUT_MS;
+
   return {
     config: validatedConfig,
     getHeaders: () => ({
@@ -23,6 +27,7 @@ export function createServarrClient(config: ServarrClientConfig) {
       ...validatedConfig.headers,
     }),
     getBaseUrl: () => validatedConfig.baseUrl,
+    getTimeout: () => timeoutMs,
   };
 }
 
@@ -38,11 +43,29 @@ export function validateBaseUrl(baseUrl: string | undefined): string {
     throw new ConnectionError('No base URL provided');
   }
 
+  let parsed: URL;
   try {
-    new URL(baseUrl);
+    parsed = new URL(baseUrl);
   } catch {
     throw new ConnectionError(`Failed to connect: Invalid URL: ${baseUrl}`);
   }
 
+  if (parsed.protocol === 'http:' && !isLocalhost(parsed.hostname)) {
+    console.warn(
+      `Warning: Using unencrypted HTTP for remote URL "${parsed.host}". Consider using HTTPS to protect your API key in transit.`
+    );
+  }
+
   return baseUrl.trim().replace(/\/$/, '');
+}
+
+function isLocalhost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '0.0.0.0' ||
+    hostname.endsWith('.local') ||
+    /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(hostname)
+  );
 }

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, jest } from 'bun:test';
 import { createServarrClient, validateApiKey, validateBaseUrl } from '../src/core/client.js';
 import { ApiKeyError, ConnectionError } from '../src/core/errors.js';
 
@@ -61,6 +61,25 @@ describe('Core Client Functions', () => {
       expect(headers['X-Api-Key']).toBe('valid-api-key');
       expect(headers['Content-Type']).toBe('application/json');
       expect(headers['User-Agent']).toBe('Tsarr/1.0.0');
+    });
+
+    it('should use default timeout of 30s', () => {
+      const client = createServarrClient({
+        baseUrl: 'http://localhost:7878',
+        apiKey: 'valid-api-key',
+      });
+
+      expect(client.getTimeout()).toBe(30_000);
+    });
+
+    it('should use custom timeout when provided', () => {
+      const client = createServarrClient({
+        baseUrl: 'http://localhost:7878',
+        apiKey: 'valid-api-key',
+        timeout: 60_000,
+      });
+
+      expect(client.getTimeout()).toBe(60_000);
     });
   });
 
@@ -147,6 +166,34 @@ describe('Core Client Functions', () => {
     it('should remove trailing slashes', () => {
       const result = validateBaseUrl('http://localhost:7878/');
       expect(result).toBe('http://localhost:7878');
+    });
+
+    it('should warn when using HTTP for remote URLs', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      validateBaseUrl('http://radarr.example.com:7878');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unencrypted HTTP'));
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn for localhost HTTP URLs', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      validateBaseUrl('http://localhost:7878');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn for private network HTTP URLs', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      validateBaseUrl('http://192.168.1.100:7878');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn for HTTPS remote URLs', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      validateBaseUrl('https://radarr.example.com');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
Closes #180

- Adds a default 30s HTTP request timeout to all clients via `AbortSignal.timeout()`, preventing requests from hanging indefinitely. Users can override via the existing `timeout` config option.
- Warns when using unencrypted HTTP for non-local URLs (localhost, `127.0.0.1`, `.local`, and RFC 1918 ranges are exempt).
- Logs caught connection errors at debug level in `config.ts` instead of silently swallowing them.

## Test plan
- [x] 6 new tests for timeout defaults, custom timeout, and HTTP warning behavior
- [x] All 255 tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)