### PR TITLE
feat(cli): add manual import commands for Radarr and Sonarr

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -219,6 +219,14 @@ tsarr radarr moviefile list --movie-id 123     # List files for a movie
 tsarr radarr moviefile get --id 456            # Get movie file details
 tsarr radarr moviefile delete --id 456         # Delete file from disk
 
+# Manual import (scan folder and import existing files)
+tsarr radarr import scan /downloads/movies                 # Preview candidates
+tsarr radarr import scan /downloads/movies --include-samples
+tsarr radarr import apply /downloads/movies --auto         # Import unambiguous matches
+tsarr radarr import apply /downloads/movies --movie-id 42  # Force-assign to one movie
+tsarr radarr import apply /downloads/movies --interactive  # Prompt for each ambiguous file
+tsarr radarr import apply /downloads/movies --auto --import-mode copy  # copy|move|auto
+
 # Quality profiles
 tsarr radarr profile list                      # List quality profiles
 tsarr radarr profile get --id 1                # Get profile details
@@ -311,6 +319,13 @@ tsarr sonarr episode search --id 1             # Trigger search for an episode
 tsarr sonarr episodefile list --series-id 1    # List files for a series
 tsarr sonarr episodefile get --id 456          # Get episode file details
 tsarr sonarr episodefile delete --id 456       # Delete file from disk
+
+# Manual import (scan folder and import existing files)
+tsarr sonarr import scan /downloads/tv                    # Preview candidates
+tsarr sonarr import apply /downloads/tv --auto            # Import unambiguous matches
+tsarr sonarr import apply /downloads/tv --series-id 12    # Restrict to one series
+tsarr sonarr import apply /downloads/tv --interactive     # Prompt for each ambiguous file
+tsarr sonarr import apply /downloads/tv --auto --import-mode copy  # copy|move|auto
 
 # Quality profiles
 tsarr sonarr profile list                      # List quality profiles

--- a/src/cli/commands/manual-import.ts
+++ b/src/cli/commands/manual-import.ts
@@ -1,0 +1,76 @@
+const SAMPLE_SIZE_THRESHOLD = 50 * 1024 * 1024;
+const SAMPLE_NAME_PATTERN = /(^|[._\- /\\])sample([._\- /\\]|$)/i;
+
+export function isSampleCandidate(item: {
+  name?: string | null;
+  relativePath?: string | null;
+  path?: string | null;
+  size?: number;
+}): boolean {
+  const names = [item.name, item.relativePath, item.path].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  if (names.some(name => SAMPLE_NAME_PATTERN.test(name))) return true;
+  if (typeof item.size === 'number' && item.size > 0 && item.size < SAMPLE_SIZE_THRESHOLD)
+    return true;
+  return false;
+}
+
+export function filterSamples<
+  T extends {
+    name?: string | null;
+    relativePath?: string | null;
+    path?: string | null;
+    size?: number;
+  },
+>(items: T[], includeSamples: boolean): T[] {
+  if (includeSamples) return items;
+  return items.filter(item => !isSampleCandidate(item));
+}
+
+export type ImportPartition<T> = {
+  ready: T[];
+  ambiguous: T[];
+};
+
+export function partitionCandidates<
+  T extends {
+    rejections?: Array<unknown> | null;
+    movie?: { id?: number } | null;
+    series?: { id?: number } | null;
+    episodes?: Array<{ id?: number }> | null;
+  },
+>(items: T[]): ImportPartition<T> {
+  const ready: T[] = [];
+  const ambiguous: T[] = [];
+
+  for (const item of items) {
+    const hasRejections = Array.isArray(item.rejections) && item.rejections.length > 0;
+    const hasMovieMatch = typeof item.movie?.id === 'number';
+    const hasSeriesMatch =
+      typeof item.series?.id === 'number' &&
+      Array.isArray(item.episodes) &&
+      item.episodes.some(e => typeof e?.id === 'number');
+
+    if (!hasRejections && (hasMovieMatch || hasSeriesMatch)) {
+      ready.push(item);
+    } else {
+      ambiguous.push(item);
+    }
+  }
+
+  return { ready, ambiguous };
+}
+
+export function formatRejections(rejections: Array<unknown> | null | undefined): string {
+  if (!Array.isArray(rejections) || rejections.length === 0) return '';
+  return rejections
+    .map(r => {
+      if (r && typeof r === 'object' && 'reason' in r) {
+        return String((r as { reason: unknown }).reason ?? '');
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('; ');
+}

--- a/src/cli/commands/radarr.ts
+++ b/src/cli/commands/radarr.ts
@@ -1,5 +1,6 @@
 import consola from 'consola';
 import { type ManualImportFilePayload, RadarrClient } from '../../clients/radarr';
+import type { CommandResource, ManualImportResource } from '../../generated/radarr/types.gen';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt';
 import { filterSamples, formatRejections, partitionCandidates } from './manual-import';
 import type { ResourceDef } from './service';
@@ -266,7 +267,8 @@ export const resources: ResourceDef[] = [
             filterExistingFiles: a['filter-existing'],
           });
           if (result?.error) return result;
-          const items = (unwrapData<any[]>(result) ?? []) as any[];
+          const items = (unwrapData<ManualImportResource[]>(result) ??
+            []) as ManualImportResource[];
           return filterSamples(items, !!a['include-samples']);
         },
       },
@@ -316,7 +318,8 @@ export const resources: ResourceDef[] = [
           });
           if (scanResult?.error) return scanResult;
 
-          const allItems = (unwrapData<any[]>(scanResult) ?? []) as any[];
+          const allItems = (unwrapData<ManualImportResource[]>(scanResult) ??
+            []) as ManualImportResource[];
           const scanned = filterSamples(allItems, !!a['include-samples']);
           if (scanned.length === 0) {
             return { message: 'No importable files found.' };
@@ -329,7 +332,7 @@ export const resources: ResourceDef[] = [
             ambiguous = [];
           }
 
-          const selected: any[] = [...ready];
+          const selected: ManualImportResource[] = [...ready];
           const skipped: Array<{ path: string; reason: string }> = [];
 
           if (interactive) {
@@ -362,9 +365,9 @@ export const resources: ResourceDef[] = [
             return { message: 'Nothing to import.', skipped };
           }
 
-          const files: ManualImportFilePayload[] = selected.map((item: any) => ({
-            path: item.path,
-            movieId: forcedMovieId ?? item.movie?.id,
+          const files: ManualImportFilePayload[] = selected.map(item => ({
+            path: item.path ?? '',
+            movieId: (forcedMovieId ?? item.movie?.id) as number,
             quality: item.quality,
             languages: item.languages,
             releaseGroup: item.releaseGroup ?? undefined,
@@ -374,7 +377,7 @@ export const resources: ResourceDef[] = [
           const commandResult = await c.applyManualImport(files, importMode);
           if (commandResult?.error) return commandResult;
 
-          const command = unwrapData<any>(commandResult);
+          const command = unwrapData<CommandResource>(commandResult);
           if (!process.stdout.isTTY && skipped.length > 0) {
             consola.warn(`Skipped ${skipped.length} file(s).`);
           }

--- a/src/cli/commands/radarr.ts
+++ b/src/cli/commands/radarr.ts
@@ -1,5 +1,7 @@
-import { RadarrClient } from '../../clients/radarr';
+import consola from 'consola';
+import { type ManualImportFilePayload, RadarrClient } from '../../clients/radarr';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt';
+import { filterSamples, formatRejections, partitionCandidates } from './manual-import';
 import type { ResourceDef } from './service';
 import {
   buildServiceCommand,
@@ -12,6 +14,9 @@ import {
   resolveRootFolderPath,
   unwrapData,
 } from './service';
+
+const IMPORT_MODES = ['auto', 'copy', 'move'] as const;
+type ImportMode = (typeof IMPORT_MODES)[number];
 
 export const resources: ResourceDef[] = [
   {
@@ -227,6 +232,161 @@ export const resources: ResourceDef[] = [
         args: [{ name: 'id', description: 'Movie file ID', required: true, type: 'number' }],
         confirmMessage: 'Are you sure you want to delete this movie file from disk?',
         run: (c: RadarrClient, a) => c.deleteMovieFile(a.id),
+      },
+    ],
+  },
+  {
+    name: 'import',
+    description: 'Manual import for movie files',
+    actions: [
+      {
+        name: 'scan',
+        description: 'Scan a folder for manual import candidates',
+        args: [
+          { name: 'path', description: 'Folder to scan', required: true },
+          { name: 'movie-id', description: 'Restrict matches to a specific movie', type: 'number' },
+          { name: 'download-id', description: 'Match against a download client ID' },
+          {
+            name: 'filter-existing',
+            description: 'Filter out files already imported',
+            type: 'boolean',
+          },
+          {
+            name: 'include-samples',
+            description: 'Include sample files in the results',
+            type: 'boolean',
+          },
+        ],
+        columns: ['relativePath', 'size', 'movie', 'quality', 'rejections'],
+        run: async (c: RadarrClient, a) => {
+          const result = await c.getManualImport({
+            folder: a.path,
+            downloadId: a['download-id'],
+            movieId: a['movie-id'],
+            filterExistingFiles: a['filter-existing'],
+          });
+          if (result?.error) return result;
+          const items = (unwrapData<any[]>(result) ?? []) as any[];
+          return filterSamples(items, !!a['include-samples']);
+        },
+      },
+      {
+        name: 'apply',
+        description: 'Perform manual import of files in a folder',
+        args: [
+          { name: 'path', description: 'Folder to import', required: true },
+          {
+            name: 'movie-id',
+            description: 'Assign all files to a specific movie',
+            type: 'number',
+          },
+          { name: 'download-id', description: 'Match against a download client ID' },
+          { name: 'auto', description: 'Import unambiguous matches only', type: 'boolean' },
+          {
+            name: 'interactive',
+            description: 'Prompt to confirm ambiguous matches',
+            type: 'boolean',
+          },
+          {
+            name: 'include-samples',
+            description: 'Include sample files',
+            type: 'boolean',
+          },
+          {
+            name: 'import-mode',
+            description: 'File transfer mode',
+            values: [...IMPORT_MODES],
+          },
+        ],
+        run: async (c: RadarrClient, a) => {
+          const autoMode = !!a.auto;
+          const interactive = !!a.interactive;
+          const forcedMovieId: number | undefined = a['movie-id'];
+
+          if (!autoMode && !interactive && forcedMovieId === undefined) {
+            throw new Error('Provide one of --auto, --interactive, or --movie-id.');
+          }
+
+          const importMode: ImportMode = (a['import-mode'] as ImportMode) ?? 'auto';
+
+          const scanResult = await c.getManualImport({
+            folder: a.path,
+            downloadId: a['download-id'],
+            filterExistingFiles: true,
+          });
+          if (scanResult?.error) return scanResult;
+
+          const allItems = (unwrapData<any[]>(scanResult) ?? []) as any[];
+          const scanned = filterSamples(allItems, !!a['include-samples']);
+          if (scanned.length === 0) {
+            return { message: 'No importable files found.' };
+          }
+
+          let { ready, ambiguous } = partitionCandidates(scanned);
+
+          if (forcedMovieId !== undefined) {
+            ready = scanned;
+            ambiguous = [];
+          }
+
+          const selected: any[] = [...ready];
+          const skipped: Array<{ path: string; reason: string }> = [];
+
+          if (interactive) {
+            for (const item of ambiguous) {
+              const label = item.relativePath ?? item.name ?? item.path ?? 'unknown file';
+              const rejection = formatRejections(item.rejections) || 'no movie match';
+              const choice = await promptSelect(`${label} — ${rejection}`, [
+                { label: 'Import anyway', value: 'import' },
+                { label: 'Skip', value: 'skip' },
+              ]);
+              if (choice === 'import' && item.movie?.id) {
+                selected.push(item);
+              } else {
+                skipped.push({
+                  path: item.path ?? label,
+                  reason: choice === 'skip' ? 'user skipped' : 'no movie match',
+                });
+              }
+            }
+          } else {
+            for (const item of ambiguous) {
+              skipped.push({
+                path: item.path ?? item.relativePath ?? 'unknown',
+                reason: formatRejections(item.rejections) || 'no movie match',
+              });
+            }
+          }
+
+          if (selected.length === 0) {
+            return { message: 'Nothing to import.', skipped };
+          }
+
+          const files: ManualImportFilePayload[] = selected.map((item: any) => ({
+            path: item.path,
+            movieId: forcedMovieId ?? item.movie?.id,
+            quality: item.quality,
+            languages: item.languages,
+            releaseGroup: item.releaseGroup ?? undefined,
+            downloadId: item.downloadId ?? a['download-id'] ?? undefined,
+          }));
+
+          const commandResult = await c.applyManualImport(files, importMode);
+          if (commandResult?.error) return commandResult;
+
+          const command = unwrapData<any>(commandResult);
+          if (!process.stdout.isTTY && skipped.length > 0) {
+            consola.warn(`Skipped ${skipped.length} file(s).`);
+          }
+
+          return {
+            imported: files.length,
+            skipped: skipped.length,
+            commandId: command?.id,
+            status: command?.status,
+            skippedFiles: skipped,
+          };
+        },
       },
     ],
   },

--- a/src/cli/commands/sonarr.ts
+++ b/src/cli/commands/sonarr.ts
@@ -1,5 +1,7 @@
-import { SonarrClient } from '../../clients/sonarr';
+import consola from 'consola';
+import { SonarrClient, type SonarrManualImportFilePayload } from '../../clients/sonarr';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt';
+import { filterSamples, formatRejections, partitionCandidates } from './manual-import';
 import type { ResourceDef } from './service';
 import {
   buildServiceCommand,
@@ -12,6 +14,9 @@ import {
   resolveRootFolderPath,
   unwrapData,
 } from './service';
+
+const IMPORT_MODES = ['auto', 'copy', 'move'] as const;
+type ImportMode = (typeof IMPORT_MODES)[number];
 
 export const resources: ResourceDef[] = [
   {
@@ -273,6 +278,179 @@ export const resources: ResourceDef[] = [
         args: [{ name: 'id', description: 'Episode file ID', required: true, type: 'number' }],
         confirmMessage: 'Are you sure you want to delete this episode file from disk?',
         run: (c: SonarrClient, a) => c.deleteEpisodeFile(a.id),
+      },
+    ],
+  },
+  {
+    name: 'import',
+    description: 'Manual import for episode files',
+    actions: [
+      {
+        name: 'scan',
+        description: 'Scan a folder for manual import candidates',
+        args: [
+          { name: 'path', description: 'Folder to scan', required: true },
+          {
+            name: 'series-id',
+            description: 'Restrict matches to a specific series',
+            type: 'number',
+          },
+          { name: 'download-id', description: 'Match against a download client ID' },
+          {
+            name: 'filter-existing',
+            description: 'Filter out files already imported',
+            type: 'boolean',
+          },
+          {
+            name: 'include-samples',
+            description: 'Include sample files in the results',
+            type: 'boolean',
+          },
+        ],
+        columns: ['relativePath', 'size', 'series', 'episodes', 'quality', 'rejections'],
+        run: async (c: SonarrClient, a) => {
+          const result = await c.getManualImport({
+            folder: a.path,
+            downloadId: a['download-id'],
+            seriesId: a['series-id'],
+            filterExistingFiles: a['filter-existing'],
+          });
+          if (result?.error) return result;
+          const items = (unwrapData<any[]>(result) ?? []) as any[];
+          return filterSamples(items, !!a['include-samples']);
+        },
+      },
+      {
+        name: 'apply',
+        description: 'Perform manual import of files in a folder',
+        args: [
+          { name: 'path', description: 'Folder to import', required: true },
+          {
+            name: 'series-id',
+            description: 'Assign all files to a specific series',
+            type: 'number',
+          },
+          { name: 'download-id', description: 'Match against a download client ID' },
+          { name: 'auto', description: 'Import unambiguous matches only', type: 'boolean' },
+          {
+            name: 'interactive',
+            description: 'Prompt to confirm ambiguous matches',
+            type: 'boolean',
+          },
+          {
+            name: 'include-samples',
+            description: 'Include sample files',
+            type: 'boolean',
+          },
+          {
+            name: 'import-mode',
+            description: 'File transfer mode',
+            values: [...IMPORT_MODES],
+          },
+        ],
+        run: async (c: SonarrClient, a) => {
+          const autoMode = !!a.auto;
+          const interactive = !!a.interactive;
+          const forcedSeriesId: number | undefined = a['series-id'];
+
+          if (!autoMode && !interactive && forcedSeriesId === undefined) {
+            throw new Error('Provide one of --auto, --interactive, or --series-id.');
+          }
+
+          const importMode: ImportMode = (a['import-mode'] as ImportMode) ?? 'auto';
+
+          const scanResult = await c.getManualImport({
+            folder: a.path,
+            downloadId: a['download-id'],
+            filterExistingFiles: true,
+          });
+          if (scanResult?.error) return scanResult;
+
+          const allItems = (unwrapData<any[]>(scanResult) ?? []) as any[];
+          const scanned = filterSamples(allItems, !!a['include-samples']);
+          if (scanned.length === 0) {
+            return { message: 'No importable files found.' };
+          }
+
+          let { ready, ambiguous } = partitionCandidates(scanned);
+
+          if (forcedSeriesId !== undefined) {
+            // Still need episode matches; force-assign only sets series
+            ready = scanned.filter(
+              (item: any) => Array.isArray(item.episodes) && item.episodes.some((e: any) => e?.id)
+            );
+            ambiguous = scanned.filter(
+              (item: any) => !Array.isArray(item.episodes) || !item.episodes.some((e: any) => e?.id)
+            );
+          }
+
+          const selected: any[] = [...ready];
+          const skipped: Array<{ path: string; reason: string }> = [];
+
+          if (interactive) {
+            for (const item of ambiguous) {
+              const label = item.relativePath ?? item.name ?? item.path ?? 'unknown file';
+              const rejection = formatRejections(item.rejections) || 'no episode match';
+              const canImport =
+                item.series?.id && Array.isArray(item.episodes) && item.episodes.length > 0;
+              const choices = canImport
+                ? [
+                    { label: 'Import anyway', value: 'import' },
+                    { label: 'Skip', value: 'skip' },
+                  ]
+                : [{ label: 'Skip', value: 'skip' }];
+              const choice = await promptSelect(`${label} — ${rejection}`, choices);
+              if (choice === 'import' && canImport) {
+                selected.push(item);
+              } else {
+                skipped.push({
+                  path: item.path ?? label,
+                  reason: choice === 'skip' ? 'user skipped' : 'no episode match',
+                });
+              }
+            }
+          } else {
+            for (const item of ambiguous) {
+              skipped.push({
+                path: item.path ?? item.relativePath ?? 'unknown',
+                reason: formatRejections(item.rejections) || 'no episode match',
+              });
+            }
+          }
+
+          if (selected.length === 0) {
+            return { message: 'Nothing to import.', skipped };
+          }
+
+          const files: SonarrManualImportFilePayload[] = selected.map((item: any) => ({
+            path: item.path,
+            seriesId: forcedSeriesId ?? item.series?.id,
+            episodeIds: (item.episodes ?? [])
+              .map((e: any) => e?.id)
+              .filter((id: unknown): id is number => typeof id === 'number'),
+            quality: item.quality,
+            languages: item.languages,
+            releaseGroup: item.releaseGroup ?? undefined,
+            downloadId: item.downloadId ?? a['download-id'] ?? undefined,
+            episodeFileId: item.episodeFileId ?? undefined,
+          }));
+
+          const commandResult = await c.applyManualImport(files, importMode);
+          if (commandResult?.error) return commandResult;
+
+          const command = unwrapData<any>(commandResult);
+          if (!process.stdout.isTTY && skipped.length > 0) {
+            consola.warn(`Skipped ${skipped.length} file(s).`);
+          }
+
+          return {
+            imported: files.length,
+            skipped: skipped.length,
+            commandId: command?.id,
+            status: command?.status,
+            skippedFiles: skipped,
+          };
+        },
       },
     ],
   },

--- a/src/cli/commands/sonarr.ts
+++ b/src/cli/commands/sonarr.ts
@@ -1,5 +1,6 @@
 import consola from 'consola';
 import { SonarrClient, type SonarrManualImportFilePayload } from '../../clients/sonarr';
+import type { CommandResource, ManualImportResource } from '../../generated/sonarr/types.gen';
 import { promptConfirm, promptIfMissing, promptSelect } from '../prompt';
 import { filterSamples, formatRejections, partitionCandidates } from './manual-import';
 import type { ResourceDef } from './service';
@@ -316,7 +317,8 @@ export const resources: ResourceDef[] = [
             filterExistingFiles: a['filter-existing'],
           });
           if (result?.error) return result;
-          const items = (unwrapData<any[]>(result) ?? []) as any[];
+          const items = (unwrapData<ManualImportResource[]>(result) ??
+            []) as ManualImportResource[];
           return filterSamples(items, !!a['include-samples']);
         },
       },
@@ -366,7 +368,8 @@ export const resources: ResourceDef[] = [
           });
           if (scanResult?.error) return scanResult;
 
-          const allItems = (unwrapData<any[]>(scanResult) ?? []) as any[];
+          const allItems = (unwrapData<ManualImportResource[]>(scanResult) ??
+            []) as ManualImportResource[];
           const scanned = filterSamples(allItems, !!a['include-samples']);
           if (scanned.length === 0) {
             return { message: 'No importable files found.' };
@@ -377,14 +380,14 @@ export const resources: ResourceDef[] = [
           if (forcedSeriesId !== undefined) {
             // Still need episode matches; force-assign only sets series
             ready = scanned.filter(
-              (item: any) => Array.isArray(item.episodes) && item.episodes.some((e: any) => e?.id)
+              item => Array.isArray(item.episodes) && item.episodes.some(e => e?.id)
             );
             ambiguous = scanned.filter(
-              (item: any) => !Array.isArray(item.episodes) || !item.episodes.some((e: any) => e?.id)
+              item => !Array.isArray(item.episodes) || !item.episodes.some(e => e?.id)
             );
           }
 
-          const selected: any[] = [...ready];
+          const selected: ManualImportResource[] = [...ready];
           const skipped: Array<{ path: string; reason: string }> = [];
 
           if (interactive) {
@@ -422,12 +425,12 @@ export const resources: ResourceDef[] = [
             return { message: 'Nothing to import.', skipped };
           }
 
-          const files: SonarrManualImportFilePayload[] = selected.map((item: any) => ({
-            path: item.path,
-            seriesId: forcedSeriesId ?? item.series?.id,
+          const files: SonarrManualImportFilePayload[] = selected.map(item => ({
+            path: item.path ?? '',
+            seriesId: (forcedSeriesId ?? item.series?.id) as number,
             episodeIds: (item.episodes ?? [])
-              .map((e: any) => e?.id)
-              .filter((id: unknown): id is number => typeof id === 'number'),
+              .map(e => e?.id)
+              .filter((id): id is number => typeof id === 'number'),
             quality: item.quality,
             languages: item.languages,
             releaseGroup: item.releaseGroup ?? undefined,
@@ -438,7 +441,7 @@ export const resources: ResourceDef[] = [
           const commandResult = await c.applyManualImport(files, importMode);
           if (commandResult?.error) return commandResult;
 
-          const command = unwrapData<any>(commandResult);
+          const command = unwrapData<CommandResource>(commandResult);
           if (!process.stdout.isTTY && skipped.length > 0) {
             consola.warn(`Skipped ${skipped.length} file(s).`);
           }

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -7,6 +7,7 @@ import type {
   CustomFormatResource,
   DownloadClientBulkResource,
   ImportListResource,
+  ManualImportReprocessResource,
   MediaManagementConfigResource,
   MovieFileListResource,
   MovieFileResource,
@@ -14,6 +15,15 @@ import type {
   NamingConfigResource,
   QualityProfileResource,
 } from '../generated/radarr/types.gen';
+
+export type ManualImportFilePayload = {
+  path: string;
+  movieId: number;
+  quality: unknown;
+  languages?: unknown;
+  releaseGroup?: string;
+  downloadId?: string;
+};
 
 export class RadarrClient extends ServarrBaseClient {
   protected readonly ops: ServarrOps = {
@@ -250,6 +260,47 @@ export class RadarrClient extends ServarrBaseClient {
    */
   async importMovies(movies: any[]) {
     return RadarrApi.postApiV3MovieImport({ body: movies });
+  }
+
+  // Manual Import APIs
+
+  /**
+   * Get manual import candidates for a folder or download
+   */
+  async getManualImport(
+    options: {
+      folder?: string;
+      downloadId?: string;
+      movieId?: number;
+      filterExistingFiles?: boolean;
+    } = {}
+  ) {
+    const query: Record<string, any> = {};
+    if (options.folder) query.folder = options.folder;
+    if (options.downloadId) query.downloadId = options.downloadId;
+    if (options.movieId !== undefined) query.movieId = options.movieId;
+    if (options.filterExistingFiles !== undefined)
+      query.filterExistingFiles = options.filterExistingFiles;
+
+    return RadarrApi.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
+  }
+
+  /**
+   * Reprocess manual import candidates to refresh quality/match metadata.
+   * Does NOT perform the actual import — use {@link applyManualImport} for that.
+   */
+  async reprocessManualImport(files: ManualImportReprocessResource[]) {
+    return RadarrApi.postApiV3Manualimport({ body: files });
+  }
+
+  /**
+   * Execute a manual import via the command queue. Returns the command resource.
+   */
+  async applyManualImport(
+    files: ManualImportFilePayload[],
+    importMode: 'auto' | 'copy' | 'move' = 'auto'
+  ) {
+    return this.runCommand({ name: 'ManualImport', files, importMode });
   }
 
   // Movie File APIs

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -275,7 +275,12 @@ export class RadarrClient extends ServarrBaseClient {
       filterExistingFiles?: boolean;
     } = {}
   ) {
-    const query: Record<string, any> = {};
+    const query: {
+      folder?: string;
+      downloadId?: string;
+      movieId?: number;
+      filterExistingFiles?: boolean;
+    } = {};
     if (options.folder) query.folder = options.folder;
     if (options.downloadId) query.downloadId = options.downloadId;
     if (options.movieId !== undefined) query.movieId = options.movieId;

--- a/src/clients/sonarr.ts
+++ b/src/clients/sonarr.ts
@@ -10,11 +10,23 @@ import type {
   EpisodeFileResource,
   EpisodeResource,
   ImportListResource,
+  ManualImportReprocessResourceWritable,
   MediaManagementConfigResource,
   NamingConfigResource,
   QualityProfileResource,
   SeriesResource,
 } from '../generated/sonarr/types.gen';
+
+export type SonarrManualImportFilePayload = {
+  path: string;
+  seriesId: number;
+  episodeIds: number[];
+  quality: unknown;
+  languages?: unknown;
+  releaseGroup?: string;
+  downloadId?: string;
+  episodeFileId?: number;
+};
 
 /**
  * Sonarr API client for TV show management
@@ -814,28 +826,50 @@ export class SonarrClient extends ServarrBaseClient {
   // Manual Import APIs
 
   /**
-   * Get manual import candidates
+   * Get manual import candidates for a folder or download
    */
   async getManualImport(
-    folder?: string,
-    downloadId?: string,
-    seriesId?: number,
-    filterExistingFiles?: boolean
+    options: {
+      folder?: string;
+      downloadId?: string;
+      seriesId?: number;
+      filterExistingFiles?: boolean;
+    } = {}
   ) {
     const query: Record<string, any> = {};
-    if (folder) query.folder = folder;
-    if (downloadId) query.downloadId = downloadId;
-    if (seriesId !== undefined) query.seriesId = seriesId;
-    if (filterExistingFiles !== undefined) query.filterExistingFiles = filterExistingFiles;
+    if (options.folder) query.folder = options.folder;
+    if (options.downloadId) query.downloadId = options.downloadId;
+    if (options.seriesId !== undefined) query.seriesId = options.seriesId;
+    if (options.filterExistingFiles !== undefined)
+      query.filterExistingFiles = options.filterExistingFiles;
 
     return SonarrApi.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
-   * Process manual import
+   * Reprocess manual import candidates to refresh quality/match metadata.
+   * Does NOT perform the actual import — use {@link applyManualImport} for that.
    */
-  async processManualImport(files: any[]) {
+  async reprocessManualImport(files: ManualImportReprocessResourceWritable[]) {
     return SonarrApi.postApiV3Manualimport({ body: files });
+  }
+
+  /**
+   * @deprecated Use {@link reprocessManualImport}. This method only reprocesses
+   * candidates; it does not perform the import.
+   */
+  async processManualImport(files: ManualImportReprocessResourceWritable[]) {
+    return this.reprocessManualImport(files);
+  }
+
+  /**
+   * Execute a manual import via the command queue. Returns the command resource.
+   */
+  async applyManualImport(
+    files: SonarrManualImportFilePayload[],
+    importMode: 'auto' | 'copy' | 'move' = 'auto'
+  ) {
+    return this.runCommand({ name: 'ManualImport', files, importMode });
   }
 
   /**

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -66,6 +66,9 @@ describe('Client Unit Tests', () => {
 
       // Import methods
       expect(typeof client.importMovies).toBe('function');
+      expect(typeof client.getManualImport).toBe('function');
+      expect(typeof client.reprocessManualImport).toBe('function');
+      expect(typeof client.applyManualImport).toBe('function');
 
       // Movie File methods
       expect(typeof client.getMovieFiles).toBe('function');
@@ -256,6 +259,8 @@ describe('Client Unit Tests', () => {
       // Manual Import methods
       expect(typeof client.getManualImport).toBe('function');
       expect(typeof client.processManualImport).toBe('function');
+      expect(typeof client.reprocessManualImport).toBe('function');
+      expect(typeof client.applyManualImport).toBe('function');
     });
   });
 

--- a/tests/manual-import.test.ts
+++ b/tests/manual-import.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  filterSamples,
+  formatRejections,
+  isSampleCandidate,
+  partitionCandidates,
+} from '../src/cli/commands/manual-import.js';
+import { resources as radarrResources } from '../src/cli/commands/radarr.js';
+import { resources as sonarrResources } from '../src/cli/commands/sonarr.js';
+
+describe('isSampleCandidate', () => {
+  it('flags files named sample', () => {
+    expect(isSampleCandidate({ name: 'Movie.2024.sample.mkv', size: 300 * 1024 * 1024 })).toBe(
+      true
+    );
+    expect(isSampleCandidate({ relativePath: 'Movie/sample/clip.mkv' })).toBe(true);
+  });
+
+  it('flags small files below the size threshold', () => {
+    expect(isSampleCandidate({ name: 'Movie.mkv', size: 10 * 1024 * 1024 })).toBe(true);
+  });
+
+  it('does not flag normal files', () => {
+    expect(isSampleCandidate({ name: 'Movie.2024.2160p.mkv', size: 20 * 1024 * 1024 * 1024 })).toBe(
+      false
+    );
+  });
+
+  it('does not flag the word sample inside another word', () => {
+    expect(isSampleCandidate({ name: 'Resampled.2024.mkv', size: 2 * 1024 * 1024 * 1024 })).toBe(
+      false
+    );
+  });
+});
+
+describe('filterSamples', () => {
+  const items = [
+    { name: 'Movie.mkv', size: 2 * 1024 * 1024 * 1024 },
+    { name: 'Movie.sample.mkv', size: 2 * 1024 * 1024 * 1024 },
+    { name: 'tiny.mkv', size: 5 * 1024 * 1024 },
+  ];
+
+  it('removes samples by default', () => {
+    expect(filterSamples(items, false)).toHaveLength(1);
+  });
+
+  it('keeps samples when includeSamples is true', () => {
+    expect(filterSamples(items, true)).toHaveLength(3);
+  });
+});
+
+describe('partitionCandidates', () => {
+  it('treats a movie match with no rejections as ready', () => {
+    const { ready, ambiguous } = partitionCandidates([
+      { movie: { id: 1 }, rejections: [] },
+      { movie: { id: 2 }, rejections: null },
+    ]);
+    expect(ready).toHaveLength(2);
+    expect(ambiguous).toHaveLength(0);
+  });
+
+  it('treats rejections or missing match as ambiguous', () => {
+    const { ready, ambiguous } = partitionCandidates([
+      { movie: { id: 1 }, rejections: [{ reason: 'bad quality' }] },
+      { movie: null, rejections: [] },
+      { rejections: [] },
+    ]);
+    expect(ready).toHaveLength(0);
+    expect(ambiguous).toHaveLength(3);
+  });
+
+  it('handles series/episode shape for Sonarr', () => {
+    const { ready, ambiguous } = partitionCandidates([
+      { series: { id: 1 }, episodes: [{ id: 10 }], rejections: [] },
+      { series: { id: 2 }, episodes: [], rejections: [] },
+    ]);
+    expect(ready).toHaveLength(1);
+    expect(ambiguous).toHaveLength(1);
+  });
+});
+
+describe('formatRejections', () => {
+  it('returns empty string for no rejections', () => {
+    expect(formatRejections(null)).toBe('');
+    expect(formatRejections([])).toBe('');
+  });
+
+  it('joins reasons with a semicolon', () => {
+    expect(formatRejections([{ reason: 'unknown movie' }, { reason: 'already imported' }])).toBe(
+      'unknown movie; already imported'
+    );
+  });
+});
+
+describe('CLI import resource definitions', () => {
+  it('registers scan and apply actions for Radarr', () => {
+    const resource = radarrResources.find(r => r.name === 'import');
+    expect(resource).toBeDefined();
+    expect(resource!.actions.map(a => a.name)).toEqual(['scan', 'apply']);
+  });
+
+  it('registers scan and apply actions for Sonarr', () => {
+    const resource = sonarrResources.find(r => r.name === 'import');
+    expect(resource).toBeDefined();
+    expect(resource!.actions.map(a => a.name)).toEqual(['scan', 'apply']);
+  });
+
+  it('Radarr apply accepts auto, interactive, and movie-id flags', () => {
+    const resource = radarrResources.find(r => r.name === 'import')!;
+    const apply = resource.actions.find(a => a.name === 'apply')!;
+    const argNames = apply.args!.map(a => a.name);
+    expect(argNames).toContain('auto');
+    expect(argNames).toContain('interactive');
+    expect(argNames).toContain('movie-id');
+    expect(argNames).toContain('import-mode');
+  });
+
+  it('Sonarr apply accepts series-id instead of movie-id', () => {
+    const resource = sonarrResources.find(r => r.name === 'import')!;
+    const apply = resource.actions.find(a => a.name === 'apply')!;
+    const argNames = apply.args!.map(a => a.name);
+    expect(argNames).toContain('series-id');
+    expect(argNames).not.toContain('movie-id');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #197.

Adds `tsarr radarr import scan|apply` and `tsarr sonarr import scan|apply`, wrapping the Servarr `/api/v3/manualimport` endpoint plus the `ManualImport` command queue. Lets users bring pre-existing or out-of-workflow media into their library without the UI.

- `scan <path>` — list import candidates with matched movie/series, episodes, quality, and any rejections. Read-only preview.
- `apply <path>` — perform the import. Flags: `--auto` (import unambiguous matches, skip the rest), `--interactive` (prompt per ambiguous file), `--movie-id`/`--series-id` (force-assign all files), `--include-samples`, `--import-mode=auto|copy|move`, `--download-id`.
- Sample filter (heuristic: `/sample/` in name or <50 MB) is applied client-side before matching.

Also aligns the existing Sonarr manual-import wrapper:
- Renames the mis-labeled `processManualImport` → `reprocessManualImport` (the endpoint re-scores candidates, it doesn't import). Old name kept as deprecated alias.
- Converts `getManualImport` to an options object for parity with Radarr.
- Adds `applyManualImport` on both clients (posts to the command queue).

## Test plan

- [x] Unit tests for sample filter and candidate partition logic (`tests/manual-import.test.ts`)
- [x] CLI resource/action definition tests
- [x] Client wrapper method assertions in `tests/clients-unit.test.ts`
- [x] Full suite: 283 passing, typecheck clean, Biome clean
- [x] **Live end-to-end against real Radarr + Sonarr Docker containers**:
  - Added The Matrix to Radarr, Lost to Sonarr
  - `radarr import scan /downloads` matched the movie with Bluray-1080p quality
  - `radarr import apply --movie-id 1 --import-mode copy` moved file to `/movies/The Matrix (1999)/` and registered movieFile record
  - `sonarr import scan /downloads` matched Lost S01E01, left unrelated file unmatched
  - `sonarr import apply --series-id 1 --import-mode copy` moved file to `/tv/Lost/`, skipped The Matrix with reason "Unknown Series"
  - `sonarr import apply --auto` correctly reported per-file skip reasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New manual import CLI for Radarr and Sonarr: `tsarr ... import scan` and `... import apply` with interactive, auto, and import-mode (copy|move) options; ability to force IDs and batch-apply imports; sample-file handling and ambiguous-vs-ready partitioning.

* **Documentation**
  * CLI guide updated with new Radarr and Sonarr import commands and options.

* **Tests**
  * Added unit tests covering sample detection, filtering, partitioning, rejection formatting, and CLI registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->