### PR TITLE
fix(qbittorrent): rewrite cookie name on Request objects for qBT 5.x

### DIFF
--- a/src/clients/qbittorrent.ts
+++ b/src/clients/qbittorrent.ts
@@ -67,14 +67,27 @@ export class QBittorrentClient {
     input: RequestInfo | URL,
     init?: RequestInit
   ): Promise<Response> {
-    if (!init?.headers || this.cookieName === 'SID') {
+    if (this.cookieName === 'SID') {
       return baseFetch(input, init);
     }
-    const headers = new Headers(init.headers);
-    const cookie = headers.get('cookie');
-    if (cookie?.includes('SID=')) {
-      headers.set('cookie', cookie.replace(/(^|;\s*)SID=/, `$1${this.cookieName}=`));
-      return baseFetch(input, { ...init, headers });
+    // The generated SDK may pass either (url, init) or a pre-built Request.
+    // Rewrite the Cookie header in whichever form actually carries it.
+    if (input instanceof Request) {
+      const cookie = input.headers.get('cookie');
+      if (cookie?.includes('SID=')) {
+        const headers = new Headers(input.headers);
+        headers.set('cookie', cookie.replace(/(^|;\s*)SID=/, `$1${this.cookieName}=`));
+        return baseFetch(new Request(input, { headers }), init);
+      }
+      return baseFetch(input, init);
+    }
+    if (init?.headers) {
+      const headers = new Headers(init.headers);
+      const cookie = headers.get('cookie');
+      if (cookie?.includes('SID=')) {
+        headers.set('cookie', cookie.replace(/(^|;\s*)SID=/, `$1${this.cookieName}=`));
+        return baseFetch(input, { ...init, headers });
+      }
     }
     return baseFetch(input, init);
   }

--- a/tests/clients.test.ts
+++ b/tests/clients.test.ts
@@ -156,4 +156,56 @@ describe('Tsarr Client Tests', () => {
       expect(typeof qbit.deleteTorrents).toBe('function');
     });
   });
+
+  describe('QBittorrentClient auth flow', () => {
+    type LoginResponse = () => Response;
+
+    async function captureCookieOnApiCall(loginResponse: LoginResponse): Promise<string | null> {
+      const calls: { url: string; cookie: string | null }[] = [];
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input instanceof Request ? input.url : input.toString();
+        const cookie =
+          input instanceof Request
+            ? input.headers.get('cookie')
+            : init?.headers
+              ? new Headers(init.headers).get('cookie')
+              : null;
+        calls.push({ url, cookie });
+        if (url.endsWith('/api/v2/auth/login')) return loginResponse();
+        if (url.endsWith('/api/v2/app/version')) return new Response('v5.0.0', { status: 200 });
+        return new Response('not mocked', { status: 500 });
+      }) as typeof globalThis.fetch;
+      try {
+        const client = new QBittorrentClient({
+          baseUrl: 'http://localhost:8080',
+          username: 'admin',
+          password: 'adminadmin',
+        });
+        await client.getAppVersion();
+        return calls.find(c => c.url.endsWith('/api/v2/app/version'))?.cookie ?? null;
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    }
+
+    it('sends SID cookie against qBT 4.x (200 + "Ok." + SID=)', async () => {
+      const cookie = await captureCookieOnApiCall(
+        () => new Response('Ok.', { status: 200, headers: { 'set-cookie': 'SID=abc123; path=/' } })
+      );
+      expect(cookie).toContain('SID=abc123');
+    });
+
+    it('sends QBT_SID_<port> cookie against qBT 5.x (204 + empty + QBT_SID_8080=)', async () => {
+      const cookie = await captureCookieOnApiCall(
+        () =>
+          new Response(null, {
+            status: 204,
+            headers: { 'set-cookie': 'QBT_SID_8080=xyz789; path=/; HttpOnly' },
+          })
+      );
+      expect(cookie).toContain('QBT_SID_8080=xyz789');
+      expect(cookie).not.toContain('SID=xyz789');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes qBittorrent 5.x authentication (#205). Login already captured the new `QBT_SID_<port>` cookie name, but the outgoing-header rewrite only ran when `fetch` was called as `(url, init)` — the generated SDK passes a pre-built `Request`, so every authenticated call still went out with `Cookie: SID=…` and was rejected with 403.

## Changes

- `src/clients/qbittorrent.ts`: handle both fetch call shapes in `fetchWithCookieName` — clone the `Request` with a rewritten `Cookie` header when input is a `Request`, otherwise keep the existing `init.headers` path.
- `tests/clients.test.ts`: add regression tests covering both qBT 4.x (`200 + "Ok." + SID=`) and qBT 5.x (`204 + QBT_SID_<port>=`) auth flows end-to-end against the SDK.

## Testing

- [x] `bun test` passes (285 tests)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Verified end-to-end against a real `lscr.io/linuxserver/qbittorrent:5.2.0` container: pre-fix code silently 403s; fixed code returns real `appVersion`/`apiVersion`.

## Related issues

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cookie handling for qBittorrent authentication. Cookie rewriting now works consistently across various request scenarios that were previously bypassed, ensuring more reliable authentication.

* **Tests**
  * Added authentication flow test suite validating session cookie behavior across different qBittorrent versions, confirming correct cookie handling for version-specific implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbeverhelst/Tsarr/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->