### PR TITLE
fix(scripts): format refreshed specs with biome to avoid noise PRs

### DIFF
--- a/scripts/refresh-specs.ts
+++ b/scripts/refresh-specs.ts
@@ -68,6 +68,22 @@ const SERVICE_SPECS: ServiceSpec[] = [
   },
 ];
 
+async function formatJson(content: string, filePath: string): Promise<string> {
+  const proc = Bun.spawn(['bunx', 'biome', 'format', `--stdin-file-path=${filePath}`], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  proc.stdin.write(content);
+  await proc.stdin.end();
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`biome format failed for ${filePath}: ${stderr}`);
+  }
+  return stdout;
+}
+
 async function fetchSpec(service: ServiceSpec) {
   const source = process.env[service.envVar] || service.defaultUrl;
   if (!source) {
@@ -98,7 +114,7 @@ async function fetchSpec(service: ServiceSpec) {
   const raw = await response.text();
   const parsed =
     source.endsWith('.yaml') || source.endsWith('.yml') ? YAML.parse(raw) : JSON.parse(raw);
-  const next = `${JSON.stringify(parsed, null, 2)}\n`;
+  const next = await formatJson(`${JSON.stringify(parsed, null, 2)}\n`, service.outputPath);
   const current = existsSync(service.outputPath) ? readFileSync(service.outputPath, 'utf-8') : null;
   const changed = current !== next;
 


### PR DESCRIPTION
## Summary

The weekly `Refresh OpenAPI Specs` workflow was opening PRs (e.g. #207) whose entire diff was formatting churn — `JSON.stringify(..., null, 2)` always emits arrays multi-line, but the checked-in specs are formatted by Biome (line width 100), which inlines short arrays like `["http", "https"]`. So every run produced a "change" even when upstream content was identical.

## Changes

- Pipe the JSON output through `biome format --stdin-file-path=<path>` in `scripts/refresh-specs.ts` before comparing/writing, so refreshed specs match the checked-in formatting.

## Testing

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run refresh:specs` locally reports "No change" for all 7 specs (vs. previously rewriting all of them); `git status` is clean afterwards.

## Related issues

Once merged, PR #207 can be closed — its diff is 100% formatting noise (verified by comparing normalized JSON of each spec on the PR branch vs. `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved consistency of generated specification files by implementing standardized JSON formatting during the specification refresh process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbeverhelst/Tsarr/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->