### PR TITLE
fix(package): exclude sourcemaps from published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   },
   "files": [
     "dist",
-    "!dist/binaries"
+    "!dist/binaries",
+    "!dist/**/*.map"
   ],
   "keywords": [
     "servarr",


### PR DESCRIPTION
## What

Adds `!dist/**/*.map` to the `files` field so sourcemaps are no longer published to npm.

## Why

The npm tarball roughly doubled from **508 KB (v2.10)** to **1.03 MB (v2.11)**. The cause was traced to #193 ("community health files and CI hardening"), which added `--sourcemap=linked` to every `bun build` command. That emits a `.js.map` beside each bundle, and since `files` publishes the whole `dist` folder, every map — including the large generated OpenAPI clients — shipped to consumers.

The sourcemaps were a debuggability nice-to-have bundled into a broad hardening PR; the publish-size cost wasn't weighed at the time. They provide no runtime value to SDK consumers.

## Approach

Keep `--sourcemap=linked` in the build (maps stay available for local/CI debugging) but exclude them from the published package. This mirrors the existing `!dist/binaries` exclusion already in `files`.

This should bring the tarball back to roughly its v2.10 size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the size of the published package by excluding extra build artifacts.
  * Source maps and binary files are no longer included in the npm release bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->