### PR TITLE
feat(radarr): Adds getRelease/addRelease client methods

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,8 +127,11 @@ const queue = await radarr.getQueue();
 // Remove item from queue
 await radarr.deleteQueueItem(queueId);
 
-// Grab release
-await radarr.grabRelease(releaseGuid);
+// Search releases for a movie
+const releases = await radarr.getRelease(movieId);
+
+// Grab/push a release
+await radarr.addRelease(release);
 ```
 
 ### Quality Management

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -805,6 +805,20 @@ export class RadarrClient extends ServarrBaseClient {
   async getDiskSpace() {
     return RadarrApi.getApiV3Diskspace();
   }
+
+  /**
+   * Search for releases, optionally scoped to a movie
+   */
+  async getRelease(movieId?: number) {
+    return RadarrApi.getApiV3Release(movieId === undefined ? {} : { query: { movieId } });
+  }
+
+  /**
+   * Grab/push a release
+   */
+  async addRelease(release: RadarrApi.ReleaseResource) {
+    return RadarrApi.postApiV3Release({ body: release });
+  }
 }
 
 // Re-export types for external consumption

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -165,6 +165,10 @@ describe('Client Unit Tests', () => {
 
       // Config methods
       expect(typeof client.updateConfig).toBe('function');
+
+      // Release methods
+      expect(typeof client.getRelease).toBe('function');
+      expect(typeof client.addRelease).toBe('function');
     });
 
     it('should update configuration and return new config', () => {


### PR DESCRIPTION
## Summary
Adds `getRelease` and `àddRelease` methods on `RadarrClient` and associated smoke tests. This allows releases to be searched and fetched via the Radarr client. 
<!-- What does this PR do, and why? -->

## Testing

<!-- How did you verify this works? -->

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Manually tested the affected CLI command / SDK path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release search functionality, with optional filtering by movie.
  * Added the ability to grab or submit a selected release through Radarr integration.
* **Documentation**
  * Updated the Queue Management example to use a search-then-grab workflow.
* **Tests**
  * Extended client method coverage to include the new release-related APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->