### PR TITLE
feat(lidarr): add metadata profiles and release selection

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -152,7 +152,7 @@ tsarr lidarr <resource> <action> [args]
 | `artist` | `list` | | List all artists |
 | `artist` | `get` | `<id>` | Get artist by ID |
 | `artist` | `search` | `<term>` | Search for artists |
-| `artist` | `add` | `--term <term> [--quality-profile-id <id>] [--metadata-profile-id <id\|name>] [--root-folder <path>] [--no-search]` | Search and add an artist |
+| `artist` | `add` | `--term <term> [--quality-profile-id <id>] [--metadata-profile-id <id\|name>] [--root-folder <path>] [--monitored <true\|false>] [--no-search]` | Search and add an artist |
 | `artist` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit an artist |
 | `artist` | `refresh` | `<id>` | Refresh artist metadata |
 | `artist` | `manual-search` | `<id>` | Trigger a manual release search |

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -152,12 +152,12 @@ tsarr lidarr <resource> <action> [args]
 | `artist` | `list` | | List all artists |
 | `artist` | `get` | `<id>` | Get artist by ID |
 | `artist` | `search` | `<term>` | Search for artists |
-| `artist` | `add` | `<term>` | Search and add an artist interactively |
+| `artist` | `add` | `--term <term> [--quality-profile-id <id>] [--metadata-profile-id <id\|name>] [--root-folder <path>] [--no-search]` | Search and add an artist |
 | `artist` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit an artist |
 | `artist` | `refresh` | `<id>` | Refresh artist metadata |
 | `artist` | `manual-search` | `<id>` | Trigger a manual release search |
 | `artist` | `delete` | `<id>` | Delete an artist |
-| `album` | `list` | | List all albums |
+| `album` | `list` | `[--artist-id <id>]` | List albums, optionally for one artist |
 | `album` | `get` | `<id>` | Get album by ID |
 | `album` | `search` | `<term>` | Search for albums |
 | `album` | `add` | `<file>` | Add album from JSON file or stdin |
@@ -168,6 +168,10 @@ tsarr lidarr <resource> <action> [args]
 | `trackfile` | `delete` | `<id>` | Delete a track file from disk |
 | `profile` | `list` | | List quality profiles |
 | `profile` | `get` | `<id>` | Get quality profile by ID |
+| `metadataprofile` | `list` | | List metadata profiles |
+| `metadataprofile` | `get` | `--id <id>` | Get metadata profile by ID |
+| `release` | `list` | `--album-id <id> \| --artist-id <id>` | List full release candidates |
+| `release` | `grab` | `--file <path\|-> [--yes]` | Grab a complete candidate from JSON |
 | `tag` | `create` | `<label>` | Create a tag |
 | `tag` | `delete` | `<id>` | Delete a tag |
 | `tag` | `list` | | List all tags |

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -152,7 +152,7 @@ tsarr lidarr <resource> <action> [args]
 | `artist` | `list` | | List all artists |
 | `artist` | `get` | `<id>` | Get artist by ID |
 | `artist` | `search` | `<term>` | Search for artists |
-| `artist` | `add` | `--term <term> [--quality-profile-id <id>] [--metadata-profile-id <id\|name>] [--root-folder <path>] [--monitored <true\|false>] [--no-search]` | Search and add an artist |
+| `artist` | `add` | `--term <term> [--foreign-artist-id <id>] [--quality-profile-id <id>] [--metadata-profile-id <id\|name>] [--root-folder <path>] [--monitored <true\|false>] [--no-search]` | Search and add an artist |
 | `artist` | `edit` | `<id> [--monitored] [--quality-profile-id] [--tags]` | Edit an artist |
 | `artist` | `refresh` | `<id>` | Refresh artist metadata |
 | `artist` | `manual-search` | `<id>` | Trigger a manual release search |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -401,6 +401,8 @@ tsarr lidarr artist list                       # List all artists
 tsarr lidarr artist get --id 1                 # Get artist by ID
 tsarr lidarr artist search --term "Radiohead"  # Search
 tsarr lidarr artist add --term "Radiohead"     # Search and add interactively
+tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 \
+  --metadata-profile-id 4 --root-folder /music --no-search --yes
 tsarr lidarr artist edit --id 1 --monitored false  # Edit an artist
 tsarr lidarr artist refresh --id 1             # Refresh artist metadata
 tsarr lidarr artist manual-search --id 1       # Trigger a manual release search
@@ -408,6 +410,7 @@ tsarr lidarr artist delete --id 1              # Delete artist
 
 # Albums
 tsarr lidarr album list                        # List all albums
+tsarr lidarr album list --artist-id 1          # List albums for one artist
 tsarr lidarr album get --id 1                  # Get album by ID
 tsarr lidarr album search --term "OK Computer" # Search albums
 tsarr lidarr album add config.json             # Add from JSON file
@@ -422,6 +425,16 @@ tsarr lidarr trackfile delete --id 456         # Delete file from disk
 # Quality profiles
 tsarr lidarr profile list                      # List quality profiles
 tsarr lidarr profile get --id 1                # Get profile details
+
+# Metadata profiles
+tsarr lidarr metadataprofile list              # List metadata profiles
+tsarr lidarr metadataprofile get --id 4        # Get metadata profile details
+
+# Manual release selection
+tsarr lidarr release list --album-id 1 --json  # Full candidates for one album
+tsarr lidarr release list --artist-id 1 --json # Full candidates for one artist
+tsarr lidarr release grab --file release.json --yes  # Grab exactly one candidate
+tsarr lidarr release grab --file - --yes < release.json # Read candidate from stdin
 
 # Tags
 tsarr lidarr tag list                          # List all tags
@@ -479,6 +492,34 @@ tsarr lidarr wanted cutoff                     # Albums below quality cutoff
 tsarr lidarr importlist list                   # List import lists
 tsarr lidarr importlist get --id 1             # Get import list details
 tsarr lidarr importlist delete --id 1          # Delete an import list
+```
+
+`release list --json` preserves each complete Lidarr `ReleaseResource`, including
+quality, indexer, protocol, size, peers, rejection reasons, custom-format score,
+and download eligibility. Save one array item unchanged and pass it to
+`release grab`; the grab command posts that object back to Lidarr and requires
+confirmation (or `--yes` for non-interactive use).
+
+When `--metadata-profile-id` is omitted from `artist add`, Tsarr prompts for a
+metadata profile and preselects the chosen root folder's configured default when
+available. The option accepts either a numeric ID or an exact,
+case-insensitive profile name. `--no-search` adds and monitors the artist
+without immediately searching for missing albums.
+
+```bash
+# Add without automatic acquisition, inspect one album, then grab one saved candidate
+tsarr lidarr artist add \
+  --term "RÜFÜS DU SOL" \
+  --quality-profile-id 2 \
+  --metadata-profile-id 4 \
+  --root-folder "/data/media/music" \
+  --no-search \
+  --yes \
+  --json
+
+tsarr lidarr album list --artist-id <artistId> --json
+tsarr lidarr release list --album-id <albumId> --json > releases.json
+tsarr lidarr release grab --file selected-release.json --yes
 ```
 
 ### Readarr

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -401,7 +401,9 @@ tsarr lidarr artist list                       # List all artists
 tsarr lidarr artist get --id 1                 # Get artist by ID
 tsarr lidarr artist search --term "Radiohead"  # Search
 tsarr lidarr artist add --term "Radiohead"     # Search and add interactively
-tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 \
+tsarr lidarr artist add --term "Radiohead" \
+  --foreign-artist-id a74b1b7f-71a5-4011-9441-d0b5e4122711 \
+  --quality-profile-id 2 \
   --metadata-profile-id 4 --root-folder /music --no-search --yes
 tsarr lidarr artist edit --id 1 --monitored false  # Edit an artist
 tsarr lidarr artist refresh --id 1             # Refresh artist metadata
@@ -500,16 +502,22 @@ and download eligibility. Save one array item unchanged and pass it to
 `release grab`; the grab command posts that object back to Lidarr and requires
 confirmation (or `--yes` for non-interactive use).
 
-When `--metadata-profile-id` is omitted from `artist add`, Tsarr prompts for a
-metadata profile and preselects the chosen root folder's configured default when
-available. The option accepts either a numeric ID or an exact,
-case-insensitive profile name. `--no-search` adds and monitors the artist
-without immediately searching for missing albums.
+Use `artist search --json` to find an artist's `foreignArtistId`, then pass it
+to `artist add --foreign-artist-id` for non-interactive selection. Without the
+option, a single search result is selected automatically; multiple results
+prompt in a TTY and return an actionable error otherwise. When
+`--metadata-profile-id` is omitted, Tsarr prompts for a metadata profile and
+preselects the chosen root folder's configured default when available. The
+option accepts either a numeric ID or an exact, case-insensitive profile name.
+`--no-search` adds and monitors the artist without immediately searching for
+missing albums.
 
 ```bash
 # Add without automatic acquisition, inspect one album, then grab one saved candidate
+tsarr lidarr artist search --term "RÜFÜS DU SOL" --json
 tsarr lidarr artist add \
   --term "RÜFÜS DU SOL" \
+  --foreign-artist-id 1cfa6ee5-1189-4ade-97db-8f20a6ba5c76 \
   --quality-profile-id 2 \
   --metadata-profile-id 4 \
   --root-folder "/data/media/music" \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,6 +134,26 @@ const releases = await radarr.getRelease(movieId);
 await radarr.addRelease(release);
 ```
 
+### Lidarr metadata profiles and release selection
+
+```typescript
+// Inspect profiles before adding an artist
+const metadataProfiles = await lidarr.getMetadataProfiles();
+const metadataProfile = await lidarr.getMetadataProfile(4);
+
+// Search complete release resources for one album
+const albumCandidates = await lidarr.getRelease(albumId);
+
+// Or search all monitored albums for one artist
+const artistCandidates = await lidarr.getRelease(undefined, artistId);
+
+// Post one candidate back unchanged to grab it
+const candidate = albumCandidates.data?.[0];
+if (candidate) {
+  await lidarr.addRelease(candidate);
+}
+```
+
 ### Quality Management
 
 ```typescript

--- a/skills/tsarr/references/common-workflows.md
+++ b/skills/tsarr/references/common-workflows.md
@@ -75,7 +75,10 @@ tsarr sonarr series search --term "Breaking Bad" --limit 5 --json
 tsarr sonarr series add --term "Breaking Bad"
 
 tsarr lidarr artist search --term "Radiohead" --json
-tsarr lidarr artist add --term "Radiohead"
+tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search
+tsarr lidarr album list --artist-id <artistId> --json
+tsarr lidarr release list --album-id <albumId> --json
+tsarr lidarr release grab --file selected-release.json --yes
 
 tsarr readarr author search --term "Ursula Le Guin" --json
 tsarr readarr author add --term "Ursula Le Guin"

--- a/skills/tsarr/references/common-workflows.md
+++ b/skills/tsarr/references/common-workflows.md
@@ -75,7 +75,7 @@ tsarr sonarr series search --term "Breaking Bad" --limit 5 --json
 tsarr sonarr series add --term "Breaking Bad"
 
 tsarr lidarr artist search --term "Radiohead" --json
-tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search
+tsarr lidarr artist add --term "Radiohead" --foreign-artist-id a74b1b7f-71a5-4011-9441-d0b5e4122711 --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search --yes
 tsarr lidarr album list --artist-id <artistId> --json
 tsarr lidarr release list --album-id <albumId> --json
 tsarr lidarr release grab --file selected-release.json --yes

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -55,11 +55,14 @@ Use for artists and albums.
 tsarr lidarr artist list --json
 tsarr lidarr artist get --id 789 --json
 tsarr lidarr artist search --term "Radiohead" --json
-tsarr lidarr artist add --term "Radiohead"
+tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search
 tsarr lidarr artist refresh --id 789
-tsarr lidarr album list --json
+tsarr lidarr album list --artist-id 789 --json
 tsarr lidarr album get --id 654 --json
 tsarr lidarr album search --term "OK Computer" --json
+tsarr lidarr metadataprofile list --json
+tsarr lidarr release list --album-id 654 --json
+tsarr lidarr release grab --file selected-release.json --yes
 ```
 
 Useful helpers:

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -55,7 +55,7 @@ Use for artists and albums.
 tsarr lidarr artist list --json
 tsarr lidarr artist get --id 789 --json
 tsarr lidarr artist search --term "Radiohead" --json
-tsarr lidarr artist add --term "Radiohead" --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search
+tsarr lidarr artist add --term "Radiohead" --foreign-artist-id a74b1b7f-71a5-4011-9441-d0b5e4122711 --quality-profile-id 2 --metadata-profile-id 4 --root-folder /music --no-search --yes
 tsarr lidarr artist refresh --id 789
 tsarr lidarr album list --artist-id 789 --json
 tsarr lidarr album get --id 654 --json

--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -42,6 +42,10 @@ export const resources: ResourceDef[] = [
         description: 'Search and add an artist',
         args: [
           { name: 'term', description: 'Search term', required: true },
+          {
+            name: 'foreign-artist-id',
+            description: 'MusicBrainz artist ID from artist search',
+          },
           { name: 'quality-profile-id', description: 'Quality profile ID', type: 'number' },
           {
             name: 'metadata-profile-id',
@@ -61,17 +65,7 @@ export const resources: ResourceDef[] = [
             throw new Error('No artists found.');
           }
 
-          const artistId = await promptSelect(
-            'Select an artist:',
-            results.map((artist: any) => ({
-              label: artist.artistName,
-              value: String(artist.foreignArtistId),
-            }))
-          );
-          const artist = results.find((item: any) => String(item.foreignArtistId) === artistId);
-          if (!artist) {
-            throw new Error('Selected artist was not found in the search results.');
-          }
+          const artist = await selectArtistSearchResult(results, a['foreign-artist-id'], a.term);
 
           const profiles = unwrapData<any[]>(await c.getQualityProfiles());
           if (!Array.isArray(profiles) || profiles.length === 0) {
@@ -741,6 +735,46 @@ function getRecords<T>(result: unknown): T[] {
   if (Array.isArray(data?.records)) return data.records;
 
   return [];
+}
+
+async function selectArtistSearchResult(
+  results: Array<Record<string, any>>,
+  requestedArtistId: unknown,
+  searchTerm: unknown
+): Promise<Record<string, any>> {
+  if (requestedArtistId !== undefined) {
+    const requested = String(requestedArtistId).trim().toLowerCase();
+    const artist = results.find(
+      item => String(item.foreignArtistId).trim().toLowerCase() === requested
+    );
+    if (!artist) {
+      throw new Error(
+        `Artist with foreign ID "${String(requestedArtistId).trim()}" was not found in the search results.`
+      );
+    }
+    return artist;
+  }
+
+  if (results.length === 1) return results[0];
+
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      `Multiple artists matched "${String(searchTerm)}". Use --foreign-artist-id <id> to select one; list IDs with \`tsarr lidarr artist search --term "${String(searchTerm)}" --json\`.`
+    );
+  }
+
+  const artistId = await promptSelect(
+    'Select an artist:',
+    results.map(artist => ({
+      label: String(artist.artistName),
+      value: String(artist.foreignArtistId),
+    }))
+  );
+  const artist = results.find(item => String(item.foreignArtistId) === artistId);
+  if (!artist) {
+    throw new Error('Selected artist was not found in the search results.');
+  }
+  return artist;
 }
 
 export function resolveMetadataProfileId(

--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -413,7 +413,7 @@ export const resources: ResourceDef[] = [
         description: 'List queue items',
         columns: ['id', 'artistName', 'title', 'status', 'sizeleft', 'timeleft'],
         run: async (c: LidarrClient) => {
-          const items = unwrapData<any[]>(await c.getQueue());
+          const items = getRecords<any>(await c.getQueue());
           return items.map(withArtistName);
         },
       },
@@ -459,8 +459,8 @@ export const resources: ResourceDef[] = [
         columns: ['id', 'artistName', 'sourceTitle', 'eventType', 'date'],
         run: async (c: LidarrClient, a) => {
           const items = a.since
-            ? unwrapData<any[]>(await c.getHistorySince(a.since))
-            : unwrapData<any[]>(await c.getHistory());
+            ? getRecords<any>(await c.getHistorySince(a.since))
+            : getRecords<any>(await c.getHistory());
 
           const filtered = a.until
             ? items.filter((item: any) => new Date(item.date) <= new Date(a.until))

--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -1,7 +1,15 @@
 import { LidarrClient } from '../../clients/lidarr';
 import { promptConfirm, promptSelect } from '../prompt';
 import type { ResourceDef } from './service';
-import { buildServiceCommand, COMMAND_OUTPUT_COLUMNS, readJsonInput, unwrapData } from './service';
+import {
+  buildServiceCommand,
+  COMMAND_OUTPUT_COLUMNS,
+  parseBooleanArg,
+  readJsonInput,
+  resolveQualityProfileId,
+  resolveRootFolderPath,
+  unwrapData,
+} from './service';
 
 export const resources: ResourceDef[] = [
   {
@@ -31,7 +39,21 @@ export const resources: ResourceDef[] = [
       {
         name: 'add',
         description: 'Search and add an artist',
-        args: [{ name: 'term', description: 'Search term', required: true }],
+        args: [
+          { name: 'term', description: 'Search term', required: true },
+          { name: 'quality-profile-id', description: 'Quality profile ID', type: 'number' },
+          {
+            name: 'metadata-profile-id',
+            description: 'Metadata profile ID or name',
+          },
+          { name: 'root-folder', description: 'Root folder path' },
+          { name: 'monitored', description: 'Set monitored (true/false)' },
+          {
+            name: 'no-search',
+            description: 'Do not search for missing albums after adding',
+            type: 'boolean',
+          },
+        ],
         run: async (c: LidarrClient, a) => {
           const results = unwrapData<any[]>(await c.searchArtists(a.term));
           if (!Array.isArray(results) || results.length === 0) {
@@ -54,30 +76,71 @@ export const resources: ResourceDef[] = [
           if (!Array.isArray(profiles) || profiles.length === 0) {
             throw new Error('No quality profiles found. Configure one in Lidarr first.');
           }
-          const profileId = await promptSelect(
-            'Select quality profile:',
-            profiles.map((profile: any) => ({ label: profile.name, value: String(profile.id) }))
-          );
+          const profileId =
+            a['quality-profile-id'] !== undefined
+              ? resolveQualityProfileId(profiles, a['quality-profile-id'])
+              : Number(
+                  await promptSelect(
+                    'Select quality profile:',
+                    profiles.map((profile: any) => ({
+                      label: profile.name,
+                      value: String(profile.id),
+                    }))
+                  )
+                );
 
           const folders = unwrapData<any[]>(await c.getRootFolders());
           if (!Array.isArray(folders) || folders.length === 0) {
             throw new Error('No root folders found. Configure one in Lidarr first.');
           }
-          const rootFolderPath = await promptSelect(
-            'Select root folder:',
-            folders.map((folder: any) => ({ label: folder.path, value: folder.path }))
+          const rootFolderPath =
+            a['root-folder'] !== undefined
+              ? resolveRootFolderPath(folders, a['root-folder'])
+              : await promptSelect(
+                  'Select root folder:',
+                  folders.map((folder: any) => ({ label: folder.path, value: folder.path }))
+                );
+
+          const metadataProfiles = unwrapData<any[]>(await c.getMetadataProfiles());
+          if (!Array.isArray(metadataProfiles) || metadataProfiles.length === 0) {
+            throw new Error('No metadata profiles found. Configure one in Lidarr first.');
+          }
+
+          const selectedFolder = folders.find((folder: any) => folder?.path === rootFolderPath);
+          const defaultMetadataProfileId = selectedFolder?.defaultMetadataProfileId;
+          const hasDefaultMetadataProfile = metadataProfiles.some(
+            (profile: any) => profile?.id === defaultMetadataProfileId
+          );
+          const metadataProfileSelection =
+            a['metadata-profile-id'] ??
+            (await promptSelect(
+              'Select metadata profile:',
+              metadataProfiles.map((profile: any) => ({
+                label:
+                  hasDefaultMetadataProfile && profile.id === defaultMetadataProfileId
+                    ? `${profile.name} (root folder default)`
+                    : profile.name,
+                value: String(profile.id),
+              })),
+              hasDefaultMetadataProfile ? String(defaultMetadataProfileId) : undefined
+            ));
+          const metadataProfileId = resolveMetadataProfileId(
+            metadataProfiles,
+            metadataProfileSelection
           );
 
           const confirmed = await promptConfirm(`Add "${artist.artistName}"?`, !!a.yes);
           if (!confirmed) throw new Error('Cancelled.');
 
-          return c.addArtist({
-            ...artist,
-            qualityProfileId: Number(profileId),
-            rootFolderPath,
-            monitored: true,
-            addOptions: { searchForMissingAlbums: true },
-          });
+          return c.addArtist(
+            buildArtistAddPayload(artist, {
+              qualityProfileId: profileId,
+              metadataProfileId,
+              rootFolderPath,
+              monitored: parseBooleanArg(a.monitored, true),
+              searchForMissingAlbums: shouldSearchForMissingAlbums(a),
+            })
+          );
         },
       },
       {
@@ -132,9 +195,10 @@ export const resources: ResourceDef[] = [
       {
         name: 'list',
         description: 'List all albums',
+        args: [{ name: 'artist-id', description: 'Filter by artist ID', type: 'number' }],
         columns: ['id', 'artistName', 'title', 'monitored'],
-        run: async (c: LidarrClient) => {
-          const albums = unwrapData<any[]>(await c.getAlbums());
+        run: async (c: LidarrClient, a) => {
+          const albums = unwrapData<any[]>(await c.getAlbums(a['artist-id']));
           return albums.map(withArtistName);
         },
       },
@@ -186,6 +250,64 @@ export const resources: ResourceDef[] = [
     ],
   },
   {
+    name: 'release',
+    description: 'Search and grab releases',
+    actions: [
+      {
+        name: 'list',
+        description: 'List release candidates for one album or artist',
+        args: [
+          { name: 'album-id', description: 'Album ID', type: 'number' },
+          { name: 'artist-id', description: 'Artist ID', type: 'number' },
+        ],
+        columns: [
+          'title',
+          'artistName',
+          'albumTitle',
+          'indexer',
+          'protocol',
+          'quality',
+          'size',
+          'seeders',
+          'leechers',
+          'approved',
+          'rejected',
+          'rejections',
+          'customFormatScore',
+          'downloadAllowed',
+        ],
+        fullJson: true,
+        run: (c: LidarrClient, a) => {
+          const albumId = a['album-id'];
+          const artistId = a['artist-id'];
+          if ((albumId === undefined) === (artistId === undefined)) {
+            throw new Error('Specify exactly one of --album-id or --artist-id.');
+          }
+          return c.getRelease(albumId, artistId);
+        },
+      },
+      {
+        name: 'grab',
+        description: 'Grab a complete release candidate from JSON file or stdin',
+        args: [
+          {
+            name: 'file',
+            description: 'Release candidate JSON file path (use - for stdin)',
+            required: true,
+          },
+        ],
+        confirmMessage: 'Grab this release?',
+        run: (c: LidarrClient, a) => {
+          const release = readJsonInput(a.file);
+          if (release === null || typeof release !== 'object' || Array.isArray(release)) {
+            throw new Error('Release candidate JSON must be an object.');
+          }
+          return c.addRelease(release);
+        },
+      },
+    ],
+  },
+  {
     name: 'trackfile',
     description: 'Manage track files',
     actions: [
@@ -226,6 +348,24 @@ export const resources: ResourceDef[] = [
         description: 'Get a quality profile by ID',
         args: [{ name: 'id', description: 'Profile ID', required: true, type: 'number' }],
         run: (c: LidarrClient, a) => c.getQualityProfile(a.id),
+      },
+    ],
+  },
+  {
+    name: 'metadataprofile',
+    description: 'View metadata profiles',
+    actions: [
+      {
+        name: 'list',
+        description: 'List metadata profiles',
+        columns: ['id', 'name'],
+        run: (c: LidarrClient) => c.getMetadataProfiles(),
+      },
+      {
+        name: 'get',
+        description: 'Get a metadata profile by ID',
+        args: [{ name: 'id', description: 'Metadata profile ID', required: true, type: 'number' }],
+        run: (c: LidarrClient, a) => c.getMetadataProfile(a.id),
       },
     ],
   },
@@ -600,4 +740,49 @@ function getRecords<T>(result: unknown): T[] {
   if (Array.isArray(data?.records)) return data.records;
 
   return [];
+}
+
+export function resolveMetadataProfileId(
+  profiles: Array<{ id?: number; name?: string | null }>,
+  requestedProfile: string | number
+): number {
+  const value = String(requestedProfile).trim();
+  const numericId = /^\d+$/.test(value) ? Number(value) : undefined;
+  const matches =
+    numericId === undefined
+      ? profiles.filter(profile => profile.name?.trim().toLowerCase() === value.toLowerCase())
+      : profiles.filter(profile => profile.id === numericId);
+
+  if (matches.length === 0 || matches[0].id === undefined) {
+    throw new Error(`Metadata profile "${value}" was not found.`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Metadata profile name "${value}" is ambiguous. Use its numeric ID.`);
+  }
+
+  return Number(matches[0].id);
+}
+
+export function buildArtistAddPayload(
+  artist: Record<string, any>,
+  options: {
+    qualityProfileId: number;
+    metadataProfileId: number;
+    rootFolderPath: string;
+    monitored: boolean;
+    searchForMissingAlbums: boolean;
+  }
+) {
+  return {
+    ...artist,
+    qualityProfileId: Number(options.qualityProfileId),
+    metadataProfileId: Number(options.metadataProfileId),
+    rootFolderPath: options.rootFolderPath,
+    monitored: options.monitored,
+    addOptions: { searchForMissingAlbums: options.searchForMissingAlbums },
+  };
+}
+
+export function shouldSearchForMissingAlbums(args: Record<string, any>): boolean {
+  return !(args['no-search'] || args.search === false);
 }

--- a/src/cli/commands/lidarr.ts
+++ b/src/cli/commands/lidarr.ts
@@ -1,4 +1,5 @@
 import { LidarrClient } from '../../clients/lidarr';
+import type { ArtistResource } from '../../generated/lidarr/types.gen';
 import { promptConfirm, promptSelect } from '../prompt';
 import type { ResourceDef } from './service';
 import {
@@ -772,14 +773,17 @@ export function buildArtistAddPayload(
     monitored: boolean;
     searchForMissingAlbums: boolean;
   }
-) {
+): ArtistResource {
   return {
     ...artist,
     qualityProfileId: Number(options.qualityProfileId),
     metadataProfileId: Number(options.metadataProfileId),
     rootFolderPath: options.rootFolderPath,
     monitored: options.monitored,
-    addOptions: { searchForMissingAlbums: options.searchForMissingAlbums },
+    addOptions: {
+      monitor: options.monitored ? 'all' : 'none',
+      searchForMissingAlbums: options.searchForMissingAlbums,
+    },
   };
 }
 

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -19,6 +19,7 @@ export interface ActionDef {
   description: string;
   args?: ActionArg[];
   columns?: string[];
+  fullJson?: boolean;
   idField?: string;
   confirmMessage?: string;
   run: (client: any, args: Record<string, any>) => Promise<any>;
@@ -215,6 +216,7 @@ export function buildServiceCommand(
             formatOutput(result, {
               format,
               columns: action.columns,
+              fullJson: action.fullJson,
               idField: action.idField,
               noHeader,
               select: args.select,

--- a/src/cli/completions.ts
+++ b/src/cli/completions.ts
@@ -26,8 +26,10 @@ const SERVICE_COMMANDS: Record<string, Record<string, string[]>> = {
   },
   lidarr: {
     artist: ['list', 'get', 'search', 'add', 'edit', 'refresh', 'manual-search', 'delete'],
-    album: ['list', 'get', 'search'],
-    profile: ['list'],
+    album: ['list', 'get', 'search', 'add', 'edit', 'delete'],
+    release: ['list', 'grab'],
+    profile: ['list', 'get'],
+    metadataprofile: ['list', 'get'],
     tag: ['list'],
     rootfolder: ['list'],
     system: ['status', 'health'],

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -18,6 +18,7 @@ export function formatOutput(
   options: {
     format: OutputFormat;
     columns?: string[];
+    fullJson?: boolean;
     idField?: string;
     noHeader?: boolean;
     select?: string;
@@ -37,7 +38,7 @@ export function formatOutput(
       let output: unknown = data;
       if (options.select) {
         output = selectFields(data, options.select);
-      } else if (options.columns && Array.isArray(data)) {
+      } else if (!options.fullJson && options.columns && Array.isArray(data)) {
         output = selectFields(data, options.columns.join(','));
       }
       console.log(JSON.stringify(output, null, 2));

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -25,7 +25,8 @@ export async function promptConfirm(message: string, skipPrompt = false): Promis
 
 export async function promptSelect(
   message: string,
-  options: { label: string; value: string }[]
+  options: { label: string; value: string }[],
+  initial?: string
 ): Promise<string> {
   if (!process.stdin.isTTY) {
     throw new Error('Interactive selection requires a TTY.');
@@ -33,6 +34,7 @@ export async function promptSelect(
   const result = await consola.prompt(message, {
     type: 'select',
     options: options.map(o => ({ label: o.label, value: o.value })),
+    ...(initial === undefined ? {} : { initial }),
   });
   return result as string;
 }

--- a/src/clients/lidarr.ts
+++ b/src/clients/lidarr.ts
@@ -12,6 +12,7 @@ import type {
   MetadataProviderConfigResource,
   NamingConfigResource,
   QualityProfileResource,
+  ReleaseResource,
   TrackFileListResource,
   TrackFileResource,
 } from '../generated/lidarr/types.gen';
@@ -129,8 +130,8 @@ export class LidarrClient extends ServarrBaseClient {
   }
 
   // Album APIs
-  async getAlbums() {
-    return LidarrApi.getApiV1Album();
+  async getAlbums(artistId?: number) {
+    return LidarrApi.getApiV1Album(artistId === undefined ? {} : { query: { artistId } });
   }
 
   async getAlbum(id: number) {
@@ -278,6 +279,15 @@ export class LidarrClient extends ServarrBaseClient {
     return LidarrApi.getApiV1QualityprofileSchema();
   }
 
+  // Metadata Profile APIs
+  async getMetadataProfiles() {
+    return LidarrApi.getApiV1Metadataprofile();
+  }
+
+  async getMetadataProfile(id: number) {
+    return LidarrApi.getApiV1MetadataprofileById({ path: { id } });
+  }
+
   // Custom Format APIs
   async getCustomFormats() {
     return LidarrApi.getApiV1Customformat();
@@ -395,6 +405,26 @@ export class LidarrClient extends ServarrBaseClient {
    */
   async getDiskSpace() {
     return LidarrApi.getApiV1Diskspace();
+  }
+
+  // Release APIs
+
+  /**
+   * Search for release candidates scoped to an album or artist
+   */
+  async getRelease(albumId?: number, artistId?: number) {
+    const query: { albumId?: number; artistId?: number } = {};
+    if (albumId !== undefined) query.albumId = albumId;
+    if (artistId !== undefined) query.artistId = artistId;
+
+    return LidarrApi.getApiV1Release(Object.keys(query).length === 0 ? {} : { query });
+  }
+
+  /**
+   * Grab a complete release candidate returned by getRelease
+   */
+  async addRelease(release: ReleaseResource) {
+    return LidarrApi.postApiV1Release({ body: release });
   }
 
   // Import List APIs

--- a/tests/cli-completions.test.ts
+++ b/tests/cli-completions.test.ts
@@ -80,6 +80,9 @@ describe('Shell completions', () => {
       expect(output).toContain('movie');
       expect(output).toContain('artist');
       expect(output).toContain('author');
+      expect(output).toContain('metadataprofile');
+      expect(output).toContain('release');
+      expect(output).toContain('list grab');
     });
 
     it('includes global options', () => {

--- a/tests/cli-lidarr-defs.test.ts
+++ b/tests/cli-lidarr-defs.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'bun:test';
-import { resources as lidarrResources } from '../src/cli/commands/lidarr.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildArtistAddPayload,
+  resources as lidarrResources,
+  resolveMetadataProfileId,
+  shouldSearchForMissingAlbums,
+} from '../src/cli/commands/lidarr.js';
 import { COMMAND_OUTPUT_COLUMNS } from '../src/cli/commands/service.js';
 
 function getAction(resourceName: string, actionName: string) {
@@ -21,9 +29,11 @@ describe('Lidarr command definitions', () => {
       'downloadclient',
       'history',
       'importlist',
+      'metadataprofile',
       'notification',
       'profile',
       'queue',
+      'release',
       'rootfolder',
       'system',
       'tag',
@@ -75,6 +85,156 @@ describe('Lidarr command definitions', () => {
       expect(argNames).toContain('quality-profile-id');
       expect(argNames).toContain('tags');
     });
+
+    it('artist add exposes profile, root-folder, monitoring, and search controls', () => {
+      const action = getAction('artist', 'add');
+      const argNames = action.args!.map(a => a.name);
+      expect(argNames).toContain('quality-profile-id');
+      expect(argNames).toContain('metadata-profile-id');
+      expect(argNames).toContain('root-folder');
+      expect(argNames).toContain('monitored');
+      expect(argNames).toContain('no-search');
+    });
+  });
+
+  describe('metadata profile resource', () => {
+    it('has list and get actions', () => {
+      const profile = lidarrResources.find(r => r.name === 'metadataprofile');
+      expect(profile!.actions.map(a => a.name)).toEqual(['list', 'get']);
+    });
+
+    it('resolves metadata profiles by ID or case-insensitive name', () => {
+      const profiles = [
+        { id: 3, name: 'Standard' },
+        { id: 4, name: 'No Singles - Filtered' },
+      ];
+
+      expect(resolveMetadataProfileId(profiles, '4')).toBe(4);
+      expect(resolveMetadataProfileId(profiles, 'no singles - filtered')).toBe(4);
+    });
+
+    it('rejects missing and ambiguous metadata profiles', () => {
+      expect(() => resolveMetadataProfileId([{ id: 3, name: 'Standard' }], '4')).toThrow(
+        'Metadata profile "4" was not found.'
+      );
+      expect(() =>
+        resolveMetadataProfileId(
+          [
+            { id: 3, name: 'Duplicate' },
+            { id: 4, name: 'Duplicate' },
+          ],
+          'duplicate'
+        )
+      ).toThrow('Metadata profile name "duplicate" is ambiguous.');
+    });
+  });
+
+  describe('release resource', () => {
+    it('has list and grab actions with safe definitions', () => {
+      const release = lidarrResources.find(r => r.name === 'release');
+      expect(release!.actions.map(a => a.name)).toEqual(['list', 'grab']);
+
+      const list = getAction('release', 'list');
+      expect(list.fullJson).toBe(true);
+      expect(list.args!.map(a => a.name)).toEqual(['album-id', 'artist-id']);
+
+      const grab = getAction('release', 'grab');
+      expect(grab.confirmMessage).toBeDefined();
+      expect(grab.args!.map(a => a.name)).toEqual(['file']);
+    });
+
+    it('requires exactly one release search scope', async () => {
+      const action = getAction('release', 'list');
+      const calls: unknown[][] = [];
+      const client = {
+        getRelease: (...args: unknown[]) => {
+          calls.push(args);
+          return Promise.resolve({ data: [] });
+        },
+      };
+
+      await action.run(client, { 'album-id': 12 });
+      await action.run(client, { 'artist-id': 34 });
+      expect(calls).toEqual([
+        [12, undefined],
+        [undefined, 34],
+      ]);
+
+      expect(() => action.run(client, {})).toThrow(
+        'Specify exactly one of --album-id or --artist-id.'
+      );
+      expect(() => action.run(client, { 'album-id': 12, 'artist-id': 34 })).toThrow(
+        'Specify exactly one of --album-id or --artist-id.'
+      );
+    });
+
+    it('passes the complete release JSON to Lidarr unchanged', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'tsarr-release-'));
+      const file = join(tempDir, 'candidate.json');
+      const candidate = {
+        guid: 'candidate-guid',
+        title: 'Artist - Album [FLAC]',
+        quality: { quality: { id: 6, name: 'FLAC' } },
+        indexer: 'Music Indexer',
+        downloadUrl: 'https://example.invalid/download',
+        rejections: [],
+      };
+      writeFileSync(file, JSON.stringify(candidate));
+
+      try {
+        let received: unknown;
+        const client = {
+          addRelease: (release: unknown) => {
+            received = release;
+            return Promise.resolve({ data: release });
+          },
+        };
+
+        await getAction('release', 'grab').run(client, { file });
+        expect(received).toEqual(candidate);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('builds an artist add payload with metadata profile and disabled acquisition', () => {
+    const payload = buildArtistAddPayload(
+      { artistName: 'RÜFÜS DU SOL', metadataProfileId: 0 },
+      {
+        qualityProfileId: 2,
+        metadataProfileId: 4,
+        rootFolderPath: '/data/media/music',
+        monitored: true,
+        searchForMissingAlbums: false,
+      }
+    );
+
+    expect(payload.metadataProfileId).toBe(4);
+    expect(payload.addOptions).toEqual({ searchForMissingAlbums: false });
+  });
+
+  it('recognizes Citty negative boolean parsing for --no-search', () => {
+    expect(shouldSearchForMissingAlbums({ search: false })).toBe(false);
+    expect(shouldSearchForMissingAlbums({ 'no-search': true })).toBe(false);
+    expect(shouldSearchForMissingAlbums({})).toBe(true);
+  });
+
+  it('album list supports filtering by artist ID', async () => {
+    const action = getAction('album', 'list');
+    expect(action.args!.map(a => a.name)).toContain('artist-id');
+
+    let artistId: number | undefined;
+    await action.run(
+      {
+        getAlbums: (id?: number) => {
+          artistId = id;
+          return Promise.resolve({ data: [] });
+        },
+      },
+      { 'artist-id': 42 }
+    );
+    expect(artistId).toBe(42);
   });
 
   describe('tag resource', () => {

--- a/tests/cli-lidarr-defs.test.ts
+++ b/tests/cli-lidarr-defs.test.ts
@@ -198,6 +198,61 @@ describe('Lidarr command definitions', () => {
     });
   });
 
+  it('normalizes array and paged queue responses', async () => {
+    const action = getAction('queue', 'list');
+    const queueItems = [
+      {
+        id: 1,
+        title: 'Artist - Album',
+        artist: { artistName: 'Test Artist' },
+      },
+    ];
+
+    for (const data of [queueItems, { records: queueItems }]) {
+      const result = await action.run(
+        {
+          getQueue: () => Promise.resolve({ data }),
+        },
+        {}
+      );
+
+      expect(result).toEqual([
+        {
+          ...queueItems[0],
+          artistName: 'Test Artist',
+        },
+      ]);
+    }
+  });
+
+  it('normalizes array and paged history responses', async () => {
+    const action = getAction('history', 'list');
+    const historyItems = [
+      {
+        id: 2,
+        sourceTitle: 'Artist - Album',
+        date: '2026-07-23T12:00:00Z',
+        artist: { artistName: 'Test Artist' },
+      },
+    ];
+
+    for (const data of [historyItems, { records: historyItems }]) {
+      const result = await action.run(
+        {
+          getHistory: () => Promise.resolve({ data }),
+        },
+        {}
+      );
+
+      expect(result).toEqual([
+        {
+          ...historyItems[0],
+          artistName: 'Test Artist',
+        },
+      ]);
+    }
+  });
+
   it('builds an artist add payload with metadata profile and disabled acquisition', () => {
     const payload = buildArtistAddPayload(
       { artistName: 'RÜFÜS DU SOL', metadataProfileId: 0 },

--- a/tests/cli-lidarr-defs.test.ts
+++ b/tests/cli-lidarr-defs.test.ts
@@ -211,7 +211,29 @@ describe('Lidarr command definitions', () => {
     );
 
     expect(payload.metadataProfileId).toBe(4);
-    expect(payload.addOptions).toEqual({ searchForMissingAlbums: false });
+    expect(payload.addOptions).toEqual({
+      monitor: 'all',
+      searchForMissingAlbums: false,
+    });
+  });
+
+  it('does not monitor albums when adding an unmonitored artist', () => {
+    const payload = buildArtistAddPayload(
+      { artistName: 'RÜFÜS DU SOL', metadataProfileId: 0 },
+      {
+        qualityProfileId: 2,
+        metadataProfileId: 4,
+        rootFolderPath: '/data/media/music',
+        monitored: false,
+        searchForMissingAlbums: false,
+      }
+    );
+
+    expect(payload.monitored).toBe(false);
+    expect(payload.addOptions).toEqual({
+      monitor: 'none',
+      searchForMissingAlbums: false,
+    });
   });
 
   it('recognizes Citty negative boolean parsing for --no-search', () => {

--- a/tests/cli-lidarr-defs.test.ts
+++ b/tests/cli-lidarr-defs.test.ts
@@ -89,6 +89,7 @@ describe('Lidarr command definitions', () => {
     it('artist add exposes profile, root-folder, monitoring, and search controls', () => {
       const action = getAction('artist', 'add');
       const argNames = action.args!.map(a => a.name);
+      expect(argNames).toContain('foreign-artist-id');
       expect(argNames).toContain('quality-profile-id');
       expect(argNames).toContain('metadata-profile-id');
       expect(argNames).toContain('root-folder');

--- a/tests/cli-output.test.ts
+++ b/tests/cli-output.test.ts
@@ -93,6 +93,17 @@ describe('CLI output formatting', () => {
     ]);
   });
 
+  it('full json mode preserves complete array resources despite table columns', () => {
+    formatOutput([{ id: 1, name: 'Candidate', downloadUrl: 'https://example.invalid' }], {
+      format: 'json',
+      columns: ['id', 'name'],
+      fullJson: true,
+    });
+
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed).toEqual([{ id: 1, name: 'Candidate', downloadUrl: 'https://example.invalid' }]);
+  });
+
   it('json mode does not apply columns to single objects', () => {
     formatOutput(
       { id: 1, name: 'Alice', email: 'alice@example.com' },

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -117,6 +117,58 @@ describe('CLI smoke tests', () => {
     }
   });
 
+  it('should expose Lidarr artist profile and acquisition controls', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
+
+    try {
+      const result = spawnSync(
+        'bun',
+        ['run', 'src/cli/index.ts', 'lidarr', 'artist', 'add', '--help'],
+        {
+          cwd: process.cwd(),
+          env: buildCliEnv(tempHome),
+          encoding: 'utf-8',
+        }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('--quality-profile-id');
+      expect(result.stdout).toContain('--metadata-profile-id');
+      expect(result.stdout).toContain('--root-folder');
+      expect(result.stdout).toContain('--no-search');
+
+      const dryRun = spawnSync(
+        'bun',
+        [
+          'run',
+          'src/cli/index.ts',
+          'lidarr',
+          'artist',
+          'add',
+          '--term',
+          'Radiohead',
+          '--no-search',
+          '--dry-run',
+          '--json',
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...buildCliEnv(tempHome),
+            TSARR_LIDARR_URL: 'http://localhost:8686',
+            TSARR_LIDARR_API_KEY: 'test-key',
+          },
+          encoding: 'utf-8',
+        }
+      );
+
+      expect(dryRun.status).toBe(0);
+      expect(JSON.parse(dryRun.stdout).args.search).toBe(false);
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it('should expose the search limit flag for Radarr and Sonarr lookup commands', () => {
     const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
 
@@ -239,6 +291,40 @@ describe('CLI smoke tests', () => {
         {
           args: ['run', 'src/cli/index.ts', 'lidarr', 'importlist', 'delete', '--help'],
           expected: 'Delete an import list',
+        },
+      ];
+
+      for (const command of commands) {
+        const result = spawnSync('bun', command.args, {
+          cwd: process.cwd(),
+          env: buildCliEnv(tempHome),
+          encoding: 'utf-8',
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(command.expected);
+      }
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('should expose Lidarr metadata-profile and release workflow subcommands', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
+
+    try {
+      const commands = [
+        {
+          args: ['run', 'src/cli/index.ts', 'lidarr', 'metadataprofile', 'list', '--help'],
+          expected: 'List metadata profiles',
+        },
+        {
+          args: ['run', 'src/cli/index.ts', 'lidarr', 'release', 'list', '--help'],
+          expected: 'List release candidates for one album or artist',
+        },
+        {
+          args: ['run', 'src/cli/index.ts', 'lidarr', 'release', 'grab', '--help'],
+          expected: 'Grab a complete release candidate',
         },
       ];
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -25,6 +25,32 @@ function buildCliEnv(homeDir: string): NodeJS.ProcessEnv {
     TSARR_BAZARR_URL: '',
     TSARR_BAZARR_API_KEY: '',
   };
+}
+
+function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bun', ['run', 'src/cli/index.ts', ...args], {
+      cwd: process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', status => resolve({ status, stdout, stderr }));
+  });
 }
 
 describe('CLI smoke tests', () => {
@@ -132,6 +158,7 @@ describe('CLI smoke tests', () => {
       );
 
       expect(result.status).toBe(0);
+      expect(result.stdout).toContain('--foreign-artist-id');
       expect(result.stdout).toContain('--quality-profile-id');
       expect(result.stdout).toContain('--metadata-profile-id');
       expect(result.stdout).toContain('--root-folder');
@@ -165,6 +192,108 @@ describe('CLI smoke tests', () => {
       expect(dryRun.status).toBe(0);
       expect(JSON.parse(dryRun.stdout).args.search).toBe(false);
     } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('should add a Lidarr artist non-interactively with an explicit foreign ID', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'tsarr-cli-'));
+    let postedArtist: Record<string, unknown> | undefined;
+    let lookupTerm: string | null = null;
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (request.method === 'GET' && url.pathname === '/api/v1/artist/lookup') {
+          lookupTerm = url.searchParams.get('term');
+          if (lookupTerm === 'Unique Artist') {
+            return Response.json([
+              { artistName: 'Unique Artist', foreignArtistId: 'artist-unique' },
+            ]);
+          }
+          return Response.json([
+            { artistName: 'Radiohead Tribute', foreignArtistId: 'artist-tribute' },
+            { artistName: 'Radiohead', foreignArtistId: 'artist-radiohead' },
+          ]);
+        }
+        if (request.method === 'GET' && url.pathname === '/api/v1/qualityprofile') {
+          return Response.json([{ id: 2, name: 'Lossless' }]);
+        }
+        if (request.method === 'GET' && url.pathname === '/api/v1/rootfolder') {
+          return Response.json([{ id: 1, path: '/music', defaultMetadataProfileId: 4 }]);
+        }
+        if (request.method === 'GET' && url.pathname === '/api/v1/metadataprofile') {
+          return Response.json([{ id: 4, name: 'Standard' }]);
+        }
+        if (request.method === 'POST' && url.pathname === '/api/v1/artist') {
+          postedArtist = (await request.json()) as Record<string, unknown>;
+          return Response.json({ ...postedArtist, id: 123 });
+        }
+        return new Response('Not found', { status: 404 });
+      },
+    });
+    const buildArtistAddArgs = (term: string, foreignArtistId?: string) => [
+      'lidarr',
+      'artist',
+      'add',
+      '--term',
+      term,
+      ...(foreignArtistId === undefined ? [] : ['--foreign-artist-id', foreignArtistId]),
+      '--quality-profile-id',
+      '2',
+      '--metadata-profile-id',
+      '4',
+      '--root-folder',
+      '/music',
+      '--no-search',
+      '--yes',
+      '--json',
+    ];
+    const env = {
+      ...buildCliEnv(tempHome),
+      TSARR_LIDARR_URL: `http://127.0.0.1:${server.port}`,
+      TSARR_LIDARR_API_KEY: 'test-key',
+    };
+
+    try {
+      const result = await runCli(buildArtistAddArgs('Radiohead', 'artist-radiohead'), env);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain('Interactive selection requires a TTY.');
+      expect(lookupTerm).toBe('Radiohead');
+      expect(postedArtist).toMatchObject({
+        artistName: 'Radiohead',
+        foreignArtistId: 'artist-radiohead',
+        qualityProfileId: 2,
+        metadataProfileId: 4,
+        rootFolderPath: '/music',
+        monitored: true,
+        addOptions: {
+          monitor: 'all',
+          searchForMissingAlbums: false,
+        },
+      });
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        id: 123,
+        foreignArtistId: 'artist-radiohead',
+      });
+
+      postedArtist = undefined;
+      const uniqueResult = await runCli(buildArtistAddArgs('Unique Artist'), env);
+      expect(uniqueResult.status).toBe(0);
+      expect(postedArtist).toMatchObject({
+        artistName: 'Unique Artist',
+        foreignArtistId: 'artist-unique',
+      });
+
+      const ambiguousResult = await runCli(buildArtistAddArgs('Radiohead'), env);
+      expect(ambiguousResult.status).toBe(1);
+      expect(ambiguousResult.stderr).toContain(
+        'Multiple artists matched "Radiohead". Use --foreign-artist-id <id>'
+      );
+    } finally {
+      server.stop(true);
       rmSync(tempHome, { recursive: true, force: true });
     }
   });

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -294,6 +294,8 @@ describe('Client Unit Tests', () => {
       expect(typeof client.searchAlbums).toBe('function');
       expect(typeof client.getQualityProfiles).toBe('function');
       expect(typeof client.getQualityProfile).toBe('function');
+      expect(typeof client.getMetadataProfiles).toBe('function');
+      expect(typeof client.getMetadataProfile).toBe('function');
       expect(typeof client.getRootFolders).toBe('function');
       expect(typeof client.getCalendar).toBe('function');
       expect(typeof client.getNotifications).toBe('function');
@@ -329,6 +331,10 @@ describe('Client Unit Tests', () => {
       expect(typeof client.grabQueueItemsBulk).toBe('function');
       expect(typeof client.getQueueDetails).toBe('function');
       expect(typeof client.getQueueStatus).toBe('function');
+
+      // Release methods
+      expect(typeof client.getRelease).toBe('function');
+      expect(typeof client.addRelease).toBe('function');
 
       // Track File methods
       expect(typeof client.getTrackFiles).toBe('function');

--- a/tests/clients.test.ts
+++ b/tests/clients.test.ts
@@ -102,6 +102,10 @@ describe('Tsarr Client Tests', () => {
       expect(typeof lidarr.addArtist).toBe('function');
       expect(typeof lidarr.searchArtists).toBe('function');
       expect(typeof lidarr.getRootFolders).toBe('function');
+      expect(typeof lidarr.getMetadataProfiles).toBe('function');
+      expect(typeof lidarr.getMetadataProfile).toBe('function');
+      expect(typeof lidarr.getRelease).toBe('function');
+      expect(typeof lidarr.addRelease).toBe('function');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds the missing Lidarr metadata-profile and per-album release-selection workflow. Artist adds can now select and validate a metadata profile, honor the chosen root folder default, and avoid automatic acquisition.

## Changes

- add metadata-profile list/get client and CLI operations
- add artist-add quality, metadata, root-folder, monitoring, and no-search controls
- add album filtering by artist ID
- add full-resource release listing by album or artist
- add confirmation-protected release grabs from JSON files or stdin
- preserve complete release JSON for lossless list-to-grab round trips
- update SDK docs, CLI docs, OpenClaw references, completions, and tests

## Testing

- [x] `bun test` passes (298 tests)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Manually tested CLI help and `--no-search` dry-run parsing
- [x] `bun run build` passes

## Related issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Lidarr artist setup with quality/metadata profiles, root folder, monitoring, optional search control, and foreign artist ID support.
  * Added Lidarr `metadataprofile` commands and a `release` workflow for listing candidates and grabbing a selected release.
  * Added `album list` filtering by artist ID.
  * Updated shell completions to match the new resources and actions.
* **Documentation**
  * Expanded CLI and usage guides with end-to-end metadata profile and manual release selection examples.
* **Bug Fixes**
  * Improved JSON “full” output to preserve complete fields even when column filters are provided.
* **Tests**
  * Added/extended coverage for the new Lidarr commands and JSON behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->