### PR TITLE
docs: move the site to tsarr.robbeverhelst.com and add analytics

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Generate documentation
         run: bun run docs
         
+      - name: Write the custom domain into the artifact
+        run: echo 'tsarr.robbeverhelst.com' > ./dist/docs/CNAME
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
         

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const [movies, series] = await Promise.all([radarr.getMovies(), sonarr.getSeries
 console.log(`Library: ${movies.data?.length ?? 0} movies, ${series.data?.length ?? 0} series.`);
 ```
 
-See the **[SDK guide](./docs/usage.md)** and [auto-generated API docs](https://robbeverhelst.github.io/Tsarr/) for the full surface.
+See the **[SDK guide](./docs/usage.md)** and [auto-generated API docs](https://tsarr.robbeverhelst.com/) for the full surface.
 
 ## Supported services
 
@@ -170,7 +170,7 @@ See the **[SDK guide](./docs/usage.md)** and [auto-generated API docs](https://r
 - **[CLI guide](./docs/cli.md)** — every command, every flag
 - **[SDK guide](./docs/usage.md)** — typed clients, modular imports
 - **[Examples](./docs/examples.md)** — real-world automation scripts
-- **[API reference](https://robbeverhelst.github.io/Tsarr/)** — generated TypeScript docs
+- **[API reference](https://tsarr.robbeverhelst.com/)** — generated TypeScript docs
 
 ## Support this project
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,7 @@
 {
-  "entryPoints": ["src/index.ts"],
+  "entryPoints": [
+    "src/index.ts"
+  ],
   "out": "dist/docs",
   "name": "Tsarr Documentation",
   "readme": "README.md",
@@ -11,13 +13,29 @@
   "excludePrivate": true,
   "excludeProtected": true,
   "excludeExternals": true,
-  "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/node_modules/**", "**/dist/**", "src/cli/**"],
-  "sort": ["source-order"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/node_modules/**",
+    "**/dist/**",
+    "src/cli/**"
+  ],
+  "sort": [
+    "source-order"
+  ],
   "includeVersion": true,
   "searchInComments": true,
   "categorizeByGroup": true,
   "defaultCategory": "API",
-  "categoryOrder": ["Clients", "Core", "Types", "CLI", "*"],
+  "categoryOrder": [
+    "Clients",
+    "Core",
+    "Types",
+    "CLI",
+    "*"
+  ],
   "gitRevision": "main",
-  "gitRemote": "origin"
+  "gitRemote": "origin",
+  "customFooterHtml": "<script defer src=\"https://analytics.robbeverhelst.be/script.js\" data-website-id=\"dc15121c-ef52-44dc-b08f-5613d52d3b7c\"></script>",
+  "customFooterHtmlDisableWrapper": true
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,5 @@
 {
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "entryPoints": ["src/index.ts"],
   "out": "dist/docs",
   "name": "Tsarr Documentation",
   "readme": "README.md",
@@ -13,27 +11,13 @@
   "excludePrivate": true,
   "excludeProtected": true,
   "excludeExternals": true,
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "**/node_modules/**",
-    "**/dist/**",
-    "src/cli/**"
-  ],
-  "sort": [
-    "source-order"
-  ],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/node_modules/**", "**/dist/**", "src/cli/**"],
+  "sort": ["source-order"],
   "includeVersion": true,
   "searchInComments": true,
   "categorizeByGroup": true,
   "defaultCategory": "API",
-  "categoryOrder": [
-    "Clients",
-    "Core",
-    "Types",
-    "CLI",
-    "*"
-  ],
+  "categoryOrder": ["Clients", "Core", "Types", "CLI", "*"],
   "gitRevision": "main",
   "gitRemote": "origin",
   "customFooterHtml": "<script defer src=\"https://analytics.robbeverhelst.be/script.js\" data-website-id=\"dc15121c-ef52-44dc-b08f-5613d52d3b7c\"></script>",


### PR DESCRIPTION
Moves the docs onto their own subdomain and adds the self-hosted Umami the other sites now use.

Pages here is **Actions-based** (`upload-pages-artifact`), not branch-based, so a `CNAME` file has to exist *inside the artifact* — typedoc will not copy stray files into `dist/docs`. A step writes it immediately before `configure-pages`.

Analytics uses typedoc's `customFooterHtml` with `customFooterHtmlDisableWrapper`. `customJs` cannot be used: it only takes a script file, and Umami needs `data-website-id` as an attribute on the tag.

Verified by building: **6,304 pages**, 0 errors, the tag with the real id present in the output. The 44 warnings are pre-existing.

DNS is already in place — `tsarr.robbeverhelst.com` is a CNAME to `robbeverhelst.github.io`, DNS-only so Pages can issue its certificate. The old `github.io/Tsarr` path 301s to the new domain once Pages picks up the CNAME, so existing links — including anything pointing at the docs from the homebrew and scoop taps — keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK guide and API reference links to the new documentation website.
  * Added analytics tracking to generated API documentation.
  * Improved documentation navigation and categorization formatting.
* **Chores**
  * Configured documentation publishing for the custom domain `tsarr.robbeverhelst.com`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->