### PR TITLE
fix(core): isolate client instances so a second client cannot hijack the first

### DIFF
--- a/src/clients/base.ts
+++ b/src/clients/base.ts
@@ -74,6 +74,8 @@ export interface ServarrOps {
 
 interface RawClient {
   setConfig(config: Record<string, unknown>): unknown;
+  /** Sonarr calls this directly for two endpoints its OpenAPI spec omits. */
+  get(options: Record<string, unknown>): Promise<any>;
 }
 
 export abstract class ServarrBaseClient {

--- a/src/clients/bazarr.ts
+++ b/src/clients/bazarr.ts
@@ -1,6 +1,7 @@
+import { bindApiClient } from '../core/bind-api';
 import { createServarrClient } from '../core/client';
 import type { ServarrClientConfig } from '../core/types';
-import { client as bazarrClient } from '../generated/bazarr/client.gen';
+import { createClient, createConfig } from '../generated/bazarr/client';
 import * as BazarrApi from '../generated/bazarr/index';
 
 function getBazarrApiBaseUrl(baseUrl: string): string {
@@ -31,12 +32,15 @@ function getBazarrHeaders(config: ReturnType<typeof createServarrClient>) {
  * ```
  */
 export class BazarrClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly rawClient = createClient(createConfig({ baseUrl: 'http://localhost' }));
+  private readonly api = bindApiClient(BazarrApi, this.rawClient);
   private clientConfig: ReturnType<typeof createServarrClient>;
 
   constructor(config: ServarrClientConfig) {
     this.clientConfig = createServarrClient(config);
 
-    bazarrClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,
@@ -50,70 +54,70 @@ export class BazarrClient {
    * Get Bazarr system status and version information
    */
   async getSystemStatus() {
-    return BazarrApi.getSystemStatus();
+    return this.api.getSystemStatus();
   }
 
   /**
    * Get system health check results
    */
   async getSystemHealth() {
-    return BazarrApi.getSystemHealth();
+    return this.api.getSystemHealth();
   }
 
   /**
    * Ping the Bazarr instance
    */
   async ping() {
-    return BazarrApi.getSystemPing();
+    return this.api.getSystemPing();
   }
 
   /**
    * Get Bazarr releases
    */
   async getSystemReleases() {
-    return BazarrApi.getSystemReleases();
+    return this.api.getSystemReleases();
   }
 
   /**
    * Get system announcements
    */
   async getSystemAnnouncements() {
-    return BazarrApi.getSystemAnnouncements();
+    return this.api.getSystemAnnouncements();
   }
 
   /**
    * Dismiss an announcement by hash
    */
   async dismissAnnouncement(hash: string) {
-    return BazarrApi.postSystemAnnouncements({ query: { hash } });
+    return this.api.postSystemAnnouncements({ query: { hash } });
   }
 
   /**
    * Get system logs
    */
   async getSystemLogs() {
-    return BazarrApi.getSystemLogs();
+    return this.api.getSystemLogs();
   }
 
   /**
    * Force log rotation
    */
   async rotateLogs() {
-    return BazarrApi.deleteSystemLogs();
+    return this.api.deleteSystemLogs();
   }
 
   /**
    * Get system tasks
    */
   async getSystemTasks() {
-    return BazarrApi.getSystemTasks();
+    return this.api.getSystemTasks();
   }
 
   /**
    * Run a system task
    */
   async runSystemTask(taskId: string) {
-    return BazarrApi.postSystemTasks({ query: { taskid: taskId } });
+    return this.api.postSystemTasks({ query: { taskid: taskId } });
   }
 
   // Backup APIs
@@ -122,28 +126,28 @@ export class BazarrClient {
    * List backup files
    */
   async getBackups() {
-    return BazarrApi.getSystemBackups();
+    return this.api.getSystemBackups();
   }
 
   /**
    * Create a new backup
    */
   async createBackup() {
-    return BazarrApi.postSystemBackups();
+    return this.api.postSystemBackups();
   }
 
   /**
    * Restore a backup
    */
   async restoreBackup(filename: string) {
-    return BazarrApi.patchSystemBackups({ query: { filename } });
+    return this.api.patchSystemBackups({ query: { filename } });
   }
 
   /**
    * Delete a backup file
    */
   async deleteBackup(filename: string) {
-    return BazarrApi.deleteSystemBackups({ query: { filename } });
+    return this.api.deleteSystemBackups({ query: { filename } });
   }
 
   // Job Queue APIs
@@ -156,28 +160,28 @@ export class BazarrClient {
     if (id !== undefined) query.id = id;
     if (status) query.status = status;
 
-    return BazarrApi.getSystemJobs(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getSystemJobs(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Force start, move to top, or move to bottom a job
    */
   async manageJob(id: number, action: string) {
-    return BazarrApi.postSystemJobs({ query: { id, action } });
+    return this.api.postSystemJobs({ query: { id, action } });
   }
 
   /**
    * Delete a job from the queue
    */
   async deleteJob(id: number) {
-    return BazarrApi.deleteSystemJobs({ query: { id } });
+    return this.api.deleteSystemJobs({ query: { id } });
   }
 
   /**
    * Empty a specific jobs queue
    */
   async emptyJobQueue(queueName: 'pending' | 'failed' | 'completed') {
-    return BazarrApi.patchSystemJobs({ query: { queueName } });
+    return this.api.patchSystemJobs({ query: { queueName } });
   }
 
   // Language APIs
@@ -186,14 +190,14 @@ export class BazarrClient {
    * List available languages
    */
   async getLanguages(history?: string) {
-    return BazarrApi.getLanguages(history ? { query: { history } } : {});
+    return this.api.getLanguages(history ? { query: { history } } : {});
   }
 
   /**
    * List language profiles
    */
   async getLanguageProfiles() {
-    return BazarrApi.getLanguagesProfiles();
+    return this.api.getLanguagesProfiles();
   }
 
   // Series APIs
@@ -207,7 +211,7 @@ export class BazarrClient {
     if (start !== undefined) query.start = start;
     if (length !== undefined) query.length = length;
 
-    return BazarrApi.getSeries(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getSeries(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -218,7 +222,7 @@ export class BazarrClient {
     if (seriesId) query.seriesid = seriesId;
     if (profileId) query.profileid = profileId;
 
-    return BazarrApi.postSeries(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.postSeries(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -229,7 +233,7 @@ export class BazarrClient {
     if (seriesId !== undefined) query.seriesid = seriesId;
     if (action) query.action = action;
 
-    return BazarrApi.patchSeries(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.patchSeries(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Episodes APIs
@@ -242,7 +246,7 @@ export class BazarrClient {
     if (seriesIds) query['seriesid[]'] = seriesIds;
     if (episodeIds) query['episodeid[]'] = episodeIds;
 
-    return BazarrApi.getEpisodes(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getEpisodes(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -254,7 +258,7 @@ export class BazarrClient {
     if (length !== undefined) query.length = length;
     if (episodeIds) query['episodeid[]'] = episodeIds;
 
-    return BazarrApi.getEpisodesWanted(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getEpisodesWanted(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -266,7 +270,7 @@ export class BazarrClient {
     if (length !== undefined) query.length = length;
     if (episodeId !== undefined) query.episodeid = episodeId;
 
-    return BazarrApi.getEpisodesHistory(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getEpisodesHistory(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -279,7 +283,7 @@ export class BazarrClient {
     forced: string,
     hi: string
   ) {
-    return BazarrApi.patchEpisodesSubtitles({
+    return this.api.patchEpisodesSubtitles({
       query: { seriesid: seriesId, episodeid: episodeId, language, forced, hi },
     });
   }
@@ -295,7 +299,7 @@ export class BazarrClient {
     hi: string,
     file: Blob | File
   ) {
-    return BazarrApi.postEpisodesSubtitles({
+    return this.api.postEpisodesSubtitles({
       body: { file },
       query: { seriesid: seriesId, episodeid: episodeId, language, forced, hi },
     });
@@ -312,7 +316,7 @@ export class BazarrClient {
     hi: string,
     path: string
   ) {
-    return BazarrApi.deleteEpisodesSubtitles({
+    return this.api.deleteEpisodesSubtitles({
       query: { seriesid: seriesId, episodeid: episodeId, language, forced, hi, path },
     });
   }
@@ -327,7 +331,7 @@ export class BazarrClient {
     if (start !== undefined) query.start = start;
     if (length !== undefined) query.length = length;
 
-    return BazarrApi.getEpisodesBlacklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getEpisodesBlacklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -341,7 +345,7 @@ export class BazarrClient {
     language: string,
     subtitlesPath: string
   ) {
-    return BazarrApi.postEpisodesBlacklist({
+    return this.api.postEpisodesBlacklist({
       query: {
         seriesid: seriesId,
         episodeid: episodeId,
@@ -362,7 +366,7 @@ export class BazarrClient {
     if (provider) query.provider = provider;
     if (subsId) query.subs_id = subsId;
 
-    return BazarrApi.deleteEpisodesBlacklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.deleteEpisodesBlacklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Movies APIs
@@ -376,7 +380,7 @@ export class BazarrClient {
     if (start !== undefined) query.start = start;
     if (length !== undefined) query.length = length;
 
-    return BazarrApi.getMovies(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getMovies(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -387,7 +391,7 @@ export class BazarrClient {
     if (radarrId) query.radarrid = radarrId;
     if (profileId) query.profileid = profileId;
 
-    return BazarrApi.postMovies(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.postMovies(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -398,7 +402,7 @@ export class BazarrClient {
     if (radarrId !== undefined) query.radarrid = radarrId;
     if (action) query.action = action;
 
-    return BazarrApi.patchMovies(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.patchMovies(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -410,7 +414,7 @@ export class BazarrClient {
     if (length !== undefined) query.length = length;
     if (radarrIds) query['radarrid[]'] = radarrIds;
 
-    return BazarrApi.getMoviesWanted(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getMoviesWanted(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -422,14 +426,14 @@ export class BazarrClient {
     if (length !== undefined) query.length = length;
     if (radarrId !== undefined) query.radarrid = radarrId;
 
-    return BazarrApi.getMoviesHistory(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getMoviesHistory(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Download movie subtitles
    */
   async downloadMovieSubtitles(radarrId: number, language: string, forced: string, hi: string) {
-    return BazarrApi.patchMoviesSubtitles({
+    return this.api.patchMoviesSubtitles({
       query: { radarrid: radarrId, language, forced, hi },
     });
   }
@@ -444,7 +448,7 @@ export class BazarrClient {
     hi: string,
     file: Blob | File
   ) {
-    return BazarrApi.postMoviesSubtitles({
+    return this.api.postMoviesSubtitles({
       body: { file },
       query: { radarrid: radarrId, language, forced, hi },
     });
@@ -460,7 +464,7 @@ export class BazarrClient {
     hi: string,
     path: string
   ) {
-    return BazarrApi.deleteMoviesSubtitles({
+    return this.api.deleteMoviesSubtitles({
       query: { radarrid: radarrId, language, forced, hi, path },
     });
   }
@@ -475,7 +479,7 @@ export class BazarrClient {
     if (start !== undefined) query.start = start;
     if (length !== undefined) query.length = length;
 
-    return BazarrApi.getMoviesBlacklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getMoviesBlacklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -488,7 +492,7 @@ export class BazarrClient {
     language: string,
     subtitlesPath: string
   ) {
-    return BazarrApi.postMoviesBlacklist({
+    return this.api.postMoviesBlacklist({
       query: {
         radarrid: radarrId,
         provider,
@@ -508,7 +512,7 @@ export class BazarrClient {
     if (provider) query.provider = provider;
     if (subsId) query.subs_id = subsId;
 
-    return BazarrApi.deleteMoviesBlacklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.deleteMoviesBlacklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Provider APIs
@@ -517,21 +521,21 @@ export class BazarrClient {
    * Get subtitle providers status
    */
   async getProviders() {
-    return BazarrApi.getProviders();
+    return this.api.getProviders();
   }
 
   /**
    * Reset subtitle providers
    */
   async resetProviders() {
-    return BazarrApi.postProviders({ query: { action: 'reset' } });
+    return this.api.postProviders({ query: { action: 'reset' } });
   }
 
   /**
    * Search for episode subtitles from providers
    */
   async searchEpisodeSubtitles(episodeId: number) {
-    return BazarrApi.getProviderEpisodes({ query: { episodeid: episodeId } });
+    return this.api.getProviderEpisodes({ query: { episodeid: episodeId } });
   }
 
   /**
@@ -546,7 +550,7 @@ export class BazarrClient {
     provider: string,
     subtitle: string
   ) {
-    return BazarrApi.postProviderEpisodes({
+    return this.api.postProviderEpisodes({
       query: {
         seriesid: seriesId,
         episodeid: episodeId,
@@ -563,7 +567,7 @@ export class BazarrClient {
    * Search for movie subtitles from providers
    */
   async searchMovieSubtitles(radarrId: number) {
-    return BazarrApi.getProviderMovies({ query: { radarrid: radarrId } });
+    return this.api.getProviderMovies({ query: { radarrid: radarrId } });
   }
 
   /**
@@ -577,7 +581,7 @@ export class BazarrClient {
     provider: string,
     subtitle: string
   ) {
-    return BazarrApi.postProviderMovies({
+    return this.api.postProviderMovies({
       query: {
         radarrid: radarrId,
         hi,
@@ -594,22 +598,22 @@ export class BazarrClient {
   /**
    * Get subtitles tracks for a media file
    */
-  async getSubtitles(data: Parameters<typeof BazarrApi.getSubtitles>[0]) {
-    return BazarrApi.getSubtitles(data);
+  async getSubtitles(data: Parameters<typeof this.api.getSubtitles>[0]) {
+    return this.api.getSubtitles(data);
   }
 
   /**
    * Apply mods/tools on external subtitles
    */
-  async applySubtitleMods(data: Parameters<typeof BazarrApi.patchSubtitles>[0]) {
-    return BazarrApi.patchSubtitles(data);
+  async applySubtitleMods(data: Parameters<typeof this.api.patchSubtitles>[0]) {
+    return this.api.patchSubtitles(data);
   }
 
   /**
    * Get subtitle name info via guessit
    */
-  async getSubtitleNameInfo(data: Parameters<typeof BazarrApi.getSubtitleNameInfo>[0]) {
-    return BazarrApi.getSubtitleNameInfo(data);
+  async getSubtitleNameInfo(data: Parameters<typeof this.api.getSubtitleNameInfo>[0]) {
+    return this.api.getSubtitleNameInfo(data);
   }
 
   // History APIs
@@ -618,7 +622,7 @@ export class BazarrClient {
    * Get history statistics
    */
   async getHistoryStats() {
-    return BazarrApi.getHistoryStats();
+    return this.api.getHistoryStats();
   }
 
   // Badges APIs
@@ -627,7 +631,7 @@ export class BazarrClient {
    * Get UI badge counts
    */
   async getBadges() {
-    return BazarrApi.getBadges();
+    return this.api.getBadges();
   }
 
   // Search APIs
@@ -635,8 +639,8 @@ export class BazarrClient {
   /**
    * Search across the system
    */
-  async search(data: Parameters<typeof BazarrApi.getSearches>[0]) {
-    return BazarrApi.getSearches(data);
+  async search(data: Parameters<typeof this.api.getSearches>[0]) {
+    return this.api.getSearches(data);
   }
 
   // Filesystem APIs
@@ -645,21 +649,21 @@ export class BazarrClient {
    * Browse Bazarr file system
    */
   async browseBazarrFs(path?: string) {
-    return BazarrApi.getBrowseBazarrFs(path ? { query: { path } } : {});
+    return this.api.getBrowseBazarrFs(path ? { query: { path } } : {});
   }
 
   /**
    * Browse Radarr file system
    */
   async browseRadarrFs(path?: string) {
-    return BazarrApi.getBrowseRadarrFs(path ? { query: { path } } : {});
+    return this.api.getBrowseRadarrFs(path ? { query: { path } } : {});
   }
 
   /**
    * Browse Sonarr file system
    */
   async browseSonarrFs(path?: string) {
-    return BazarrApi.getBrowseSonarrFs(path ? { query: { path } } : {});
+    return this.api.getBrowseSonarrFs(path ? { query: { path } } : {});
   }
 
   // Webhook APIs
@@ -668,35 +672,35 @@ export class BazarrClient {
    * Test external webhook connection
    */
   async testWebhook() {
-    return BazarrApi.postSystemWebhookTest();
+    return this.api.postSystemWebhookTest();
   }
 
   /**
    * Trigger Plex webhook
    */
   async triggerPlexWebhook(payload: string) {
-    return BazarrApi.postWebHooksPlex({ query: { payload } });
+    return this.api.postWebHooksPlex({ query: { payload } });
   }
 
   /**
    * Trigger Radarr webhook
    */
-  async triggerRadarrWebhook(data: Parameters<typeof BazarrApi.postWebHooksRadarr>[0]) {
-    return BazarrApi.postWebHooksRadarr(data);
+  async triggerRadarrWebhook(data: Parameters<typeof this.api.postWebHooksRadarr>[0]) {
+    return this.api.postWebHooksRadarr(data);
   }
 
   /**
    * Trigger Sonarr webhook
    */
-  async triggerSonarrWebhook(data: Parameters<typeof BazarrApi.postWebHooksSonarr>[0]) {
-    return BazarrApi.postWebHooksSonarr(data);
+  async triggerSonarrWebhook(data: Parameters<typeof this.api.postWebHooksSonarr>[0]) {
+    return this.api.postWebHooksSonarr(data);
   }
 
   // Update configuration
   updateConfig(newConfig: Partial<ServarrClientConfig>) {
     const updatedConfig = { ...this.clientConfig.config, ...newConfig };
     this.clientConfig = createServarrClient(updatedConfig);
-    bazarrClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: getBazarrApiBaseUrl(this.clientConfig.getBaseUrl()),
       headers: getBazarrHeaders(this.clientConfig),
       auth: this.clientConfig.config.apiKey,

--- a/src/clients/jellyfin.ts
+++ b/src/clients/jellyfin.ts
@@ -1,6 +1,7 @@
+import { bindApiClient } from '../core/bind-api';
 import { createServarrClient } from '../core/client';
 import type { ServarrClientConfig } from '../core/types';
-import { client as jellyfinClient } from '../generated/jellyfin/client.gen';
+import { createClient, createConfig } from '../generated/jellyfin/client';
 import * as JellyfinApi from '../generated/jellyfin/index';
 import type {
   AddItemToPlaylistData,
@@ -75,6 +76,9 @@ type CollectionQuery = NonNullable<CreateCollectionData['query']>;
  */
 export class JellyfinClient {
   private clientConfig: ReturnType<typeof createServarrClient>;
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly rawClient = createClient(createConfig({ baseUrl: 'http://localhost' }));
+  private readonly api = bindApiClient(JellyfinApi, this.rawClient);
 
   constructor(config: ServarrClientConfig) {
     this.clientConfig = createServarrClient(config);
@@ -82,7 +86,7 @@ export class JellyfinClient {
   }
 
   private applyConfig() {
-    jellyfinClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: this.clientConfig.getBaseUrl(),
       headers: {
         // Jellyfin's own auth scheme. `X-Emby-Token` also works today but is
@@ -97,145 +101,145 @@ export class JellyfinClient {
   // System APIs
 
   async getSystemStatus() {
-    return JellyfinApi.getSystemInfo();
+    return this.api.getSystemInfo();
   }
 
   async getPublicSystemInfo() {
-    return JellyfinApi.getPublicSystemInfo();
+    return this.api.getPublicSystemInfo();
   }
 
   async ping() {
-    return JellyfinApi.getPingSystem();
+    return this.api.getPingSystem();
   }
 
   async getActivityLog(options?: ActivityQuery) {
-    return JellyfinApi.getLogEntries(options ? { query: options } : {});
+    return this.api.getLogEntries(options ? { query: options } : {});
   }
 
   // Library APIs
 
   /** Trigger a full library scan. Returns immediately; the scan runs in the background. */
   async refreshLibrary() {
-    return JellyfinApi.refreshLibrary();
+    return this.api.refreshLibrary();
   }
 
   /** Refresh metadata for a single item. */
   async refreshItem(itemId: string, options?: RefreshItemQuery) {
-    return JellyfinApi.refreshItem({
+    return this.api.refreshItem({
       path: { itemId },
       ...(options ? { query: options } : {}),
     });
   }
 
   async getVirtualFolders() {
-    return JellyfinApi.getVirtualFolders();
+    return this.api.getVirtualFolders();
   }
 
   async addVirtualFolder(
     name: string,
     options?: { collectionType?: CollectionType; paths?: string[]; refreshLibrary?: boolean }
   ) {
-    return JellyfinApi.addVirtualFolder({ query: { name, ...(options ?? {}) } });
+    return this.api.addVirtualFolder({ query: { name, ...(options ?? {}) } });
   }
 
   async removeVirtualFolder(name: string, refreshLibrary?: boolean) {
-    return JellyfinApi.removeVirtualFolder({
+    return this.api.removeVirtualFolder({
       query: { name, ...(refreshLibrary !== undefined ? { refreshLibrary } : {}) },
     });
   }
 
   async getMediaFolders() {
-    return JellyfinApi.getMediaFolders();
+    return this.api.getMediaFolders();
   }
 
   // Item APIs
 
   async getItems(options?: ItemsQuery) {
-    return JellyfinApi.getItems(options ? { query: options } : {});
+    return this.api.getItems(options ? { query: options } : {});
   }
 
   async getItem(itemId: string, userId: string) {
-    return JellyfinApi.getItem({ path: { itemId }, query: { userId } });
+    return this.api.getItem({ path: { itemId }, query: { userId } });
   }
 
   async deleteItem(itemId: string) {
-    return JellyfinApi.deleteItem({ path: { itemId } });
+    return this.api.deleteItem({ path: { itemId } });
   }
 
   async getItemCounts(userId?: string) {
-    return JellyfinApi.getItemCounts(userId ? { query: { userId } } : {});
+    return this.api.getItemCounts(userId ? { query: { userId } } : {});
   }
 
   async getLatestMedia(options: UserScoped<LatestQuery>) {
-    return JellyfinApi.getLatestMedia({ query: options });
+    return this.api.getLatestMedia({ query: options });
   }
 
   async getNextUp(options: UserScoped<NextUpQuery>) {
-    return JellyfinApi.getNextUp({ query: options });
+    return this.api.getNextUp({ query: options });
   }
 
   async getResumeItems(options: UserScoped<ResumeQuery>) {
-    return JellyfinApi.getResumeItems({ query: options });
+    return this.api.getResumeItems({ query: options });
   }
 
   async search(searchTerm: string, options?: Omit<SearchQuery, 'searchTerm'>) {
-    return JellyfinApi.getSearchHints({ query: { searchTerm, ...(options ?? {}) } });
+    return this.api.getSearchHints({ query: { searchTerm, ...(options ?? {}) } });
   }
 
   // Watched-state APIs
 
   async getItemUserData(itemId: string, userId: string) {
-    return JellyfinApi.getItemUserData({ path: { itemId }, query: { userId } });
+    return this.api.getItemUserData({ path: { itemId }, query: { userId } });
   }
 
   async markPlayed(itemId: string, userId: string) {
-    return JellyfinApi.markPlayedItem({ path: { itemId }, query: { userId } });
+    return this.api.markPlayedItem({ path: { itemId }, query: { userId } });
   }
 
   async markUnplayed(itemId: string, userId: string) {
-    return JellyfinApi.markUnplayedItem({ path: { itemId }, query: { userId } });
+    return this.api.markUnplayedItem({ path: { itemId }, query: { userId } });
   }
 
   async markFavorite(itemId: string, userId: string) {
-    return JellyfinApi.markFavoriteItem({ path: { itemId }, query: { userId } });
+    return this.api.markFavoriteItem({ path: { itemId }, query: { userId } });
   }
 
   async unmarkFavorite(itemId: string, userId: string) {
-    return JellyfinApi.unmarkFavoriteItem({ path: { itemId }, query: { userId } });
+    return this.api.unmarkFavoriteItem({ path: { itemId }, query: { userId } });
   }
 
   // Session APIs
 
   async getSessions(options?: SessionsQuery) {
-    return JellyfinApi.getSessions(options ? { query: options } : {});
+    return this.api.getSessions(options ? { query: options } : {});
   }
 
   // User APIs
 
   async getUsers() {
-    return JellyfinApi.getUsers();
+    return this.api.getUsers();
   }
 
   async getUserById(userId: string) {
-    return JellyfinApi.getUserById({ path: { userId } });
+    return this.api.getUserById({ path: { userId } });
   }
 
   async getCurrentUser() {
-    return JellyfinApi.getCurrentUser();
+    return this.api.getCurrentUser();
   }
 
   // Scheduled task APIs
 
   async getTasks() {
-    return JellyfinApi.getTasks();
+    return this.api.getTasks();
   }
 
   async startTask(taskId: string) {
-    return JellyfinApi.startTask({ path: { taskId } });
+    return this.api.startTask({ path: { taskId } });
   }
 
   async stopTask(taskId: string) {
-    return JellyfinApi.stopTask({ path: { taskId } });
+    return this.api.stopTask({ path: { taskId } });
   }
 
   // Session remote-control APIs
@@ -251,7 +255,7 @@ export class JellyfinClient {
     command: PlaystateCommand,
     options?: { seekPositionTicks?: number; controllingUserId?: string }
   ) {
-    return JellyfinApi.sendPlaystateCommand({
+    return this.api.sendPlaystateCommand({
       path: { sessionId, command },
       ...(options ? { query: options } : {}),
     });
@@ -259,12 +263,12 @@ export class JellyfinClient {
 
   /** Send a general command to a session — volume, navigation, subtitles. */
   async sendGeneralCommand(sessionId: string, command: GeneralCommand) {
-    return JellyfinApi.sendGeneralCommand({ path: { sessionId, command } });
+    return this.api.sendGeneralCommand({ path: { sessionId, command } });
   }
 
   /** Send a system command to a session — GoHome, GoToSettings, TakeScreenshot. */
   async sendSystemCommand(sessionId: string, command: SystemCommand) {
-    return JellyfinApi.sendSystemCommand({ path: { sessionId, command } });
+    return this.api.sendSystemCommand({ path: { sessionId, command } });
   }
 
   /** Display a message on a session's screen. */
@@ -278,7 +282,7 @@ export class JellyfinClient {
       ...(options?.header ? { Header: options.header } : {}),
       ...(options?.timeoutMs ? { TimeoutMs: options.timeoutMs } : {}),
     };
-    return JellyfinApi.sendMessageCommand({ path: { sessionId }, body });
+    return this.api.sendMessageCommand({ path: { sessionId }, body });
   }
 
   /** Instruct a session to play items. */
@@ -288,7 +292,7 @@ export class JellyfinClient {
     itemIds: string[],
     options?: PlayOptions
   ) {
-    return JellyfinApi.play({
+    return this.api.play({
       path: { sessionId },
       query: { playCommand, itemIds, ...(options ?? {}) },
     });
@@ -301,18 +305,18 @@ export class JellyfinClient {
     itemName: string,
     itemType: DisplayItemType
   ) {
-    return JellyfinApi.displayContent({
+    return this.api.displayContent({
       path: { sessionId },
       query: { itemId, itemName, itemType },
     });
   }
 
   async addUserToSession(sessionId: string, userId: string) {
-    return JellyfinApi.addUserToSession({ path: { sessionId, userId } });
+    return this.api.addUserToSession({ path: { sessionId, userId } });
   }
 
   async removeUserFromSession(sessionId: string, userId: string) {
-    return JellyfinApi.removeUserFromSession({ path: { sessionId, userId } });
+    return this.api.removeUserFromSession({ path: { sessionId, userId } });
   }
 
   // Playlist APIs
@@ -329,11 +333,11 @@ export class JellyfinClient {
     name: string,
     options: { userId: string; ids?: string[]; mediaType?: PlaylistMediaType }
   ) {
-    return JellyfinApi.createPlaylist({ query: { name, ...options } });
+    return this.api.createPlaylist({ query: { name, ...options } });
   }
 
   async getPlaylistItems(playlistId: string, options: UserScoped<PlaylistItemsQuery>) {
-    return JellyfinApi.getPlaylistItems({ path: { playlistId }, query: options });
+    return this.api.getPlaylistItems({ path: { playlistId }, query: options });
   }
 
   async addToPlaylist(
@@ -341,7 +345,7 @@ export class JellyfinClient {
     ids: string[],
     options: UserScoped<Omit<AddToPlaylistQuery, 'ids'>>
   ) {
-    return JellyfinApi.addItemToPlaylist({ path: { playlistId }, query: { ids, ...options } });
+    return this.api.addItemToPlaylist({ path: { playlistId }, query: { ids, ...options } });
   }
 
   /**
@@ -350,21 +354,21 @@ export class JellyfinClient {
    * (`PlaylistItemId`) rather than relying on that.
    */
   async removeFromPlaylist(playlistId: string, entryIds: string[]) {
-    return JellyfinApi.removeItemFromPlaylist({ path: { playlistId }, query: { entryIds } });
+    return this.api.removeItemFromPlaylist({ path: { playlistId }, query: { entryIds } });
   }
 
   // Collection APIs
 
   async createCollection(name: string, options?: Omit<CollectionQuery, 'name'>) {
-    return JellyfinApi.createCollection({ query: { name, ...(options ?? {}) } });
+    return this.api.createCollection({ query: { name, ...(options ?? {}) } });
   }
 
   async addToCollection(collectionId: string, ids: string[]) {
-    return JellyfinApi.addToCollection({ path: { collectionId }, query: { ids } });
+    return this.api.addToCollection({ path: { collectionId }, query: { ids } });
   }
 
   async removeFromCollection(collectionId: string, ids: string[]) {
-    return JellyfinApi.removeFromCollection({ path: { collectionId }, query: { ids } });
+    return this.api.removeFromCollection({ path: { collectionId }, query: { ids } });
   }
 
   // Update configuration

--- a/src/clients/lidarr.ts
+++ b/src/clients/lidarr.ts
@@ -1,6 +1,7 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import { bindApiClient } from '../core/bind-api';
 import type { ServarrClientConfig } from '../core/types';
-import { client as lidarrClient } from '../generated/lidarr/client.gen';
+import { createClient, createConfig } from '../generated/lidarr/client';
 import * as LidarrApi from '../generated/lidarr/index';
 import type {
   AlbumResource,
@@ -31,77 +32,80 @@ import type {
  * ```
  */
 export class LidarrClient extends ServarrBaseClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly api = bindApiClient(LidarrApi, this.rawClient);
+
   protected readonly ops: ServarrOps = {
     // System
-    getSystemStatus: LidarrApi.getApiV1SystemStatus,
-    getHealth: LidarrApi.getApiV1Health,
+    getSystemStatus: this.api.getApiV1SystemStatus,
+    getHealth: this.api.getApiV1Health,
 
     // Tags
-    getTags: LidarrApi.getApiV1Tag,
-    createTag: LidarrApi.postApiV1Tag,
-    getTagById: LidarrApi.getApiV1TagById,
-    updateTagById: LidarrApi.putApiV1TagById,
-    deleteTagById: LidarrApi.deleteApiV1TagById,
-    getTagDetails: LidarrApi.getApiV1TagDetail,
-    getTagDetailById: LidarrApi.getApiV1TagDetailById,
+    getTags: this.api.getApiV1Tag,
+    createTag: this.api.postApiV1Tag,
+    getTagById: this.api.getApiV1TagById,
+    updateTagById: this.api.putApiV1TagById,
+    deleteTagById: this.api.deleteApiV1TagById,
+    getTagDetails: this.api.getApiV1TagDetail,
+    getTagDetailById: this.api.getApiV1TagDetailById,
 
     // Notifications
-    getNotifications: LidarrApi.getApiV1Notification,
-    createNotification: LidarrApi.postApiV1Notification,
-    getNotificationById: LidarrApi.getApiV1NotificationById,
-    updateNotificationById: LidarrApi.putApiV1NotificationById,
-    deleteNotificationById: LidarrApi.deleteApiV1NotificationById,
-    getNotificationSchema: LidarrApi.getApiV1NotificationSchema,
-    testNotification: LidarrApi.postApiV1NotificationTest,
-    testAllNotifications: LidarrApi.postApiV1NotificationTestall,
+    getNotifications: this.api.getApiV1Notification,
+    createNotification: this.api.postApiV1Notification,
+    getNotificationById: this.api.getApiV1NotificationById,
+    updateNotificationById: this.api.putApiV1NotificationById,
+    deleteNotificationById: this.api.deleteApiV1NotificationById,
+    getNotificationSchema: this.api.getApiV1NotificationSchema,
+    testNotification: this.api.postApiV1NotificationTest,
+    testAllNotifications: this.api.postApiV1NotificationTestall,
 
     // Download Clients
-    getDownloadClients: LidarrApi.getApiV1Downloadclient,
-    createDownloadClient: LidarrApi.postApiV1Downloadclient,
-    getDownloadClientById: LidarrApi.getApiV1DownloadclientById,
-    updateDownloadClientById: LidarrApi.putApiV1DownloadclientById,
-    deleteDownloadClientById: LidarrApi.deleteApiV1DownloadclientById,
-    getDownloadClientSchema: LidarrApi.getApiV1DownloadclientSchema,
-    testDownloadClient: LidarrApi.postApiV1DownloadclientTest,
-    testAllDownloadClients: LidarrApi.postApiV1DownloadclientTestall,
+    getDownloadClients: this.api.getApiV1Downloadclient,
+    createDownloadClient: this.api.postApiV1Downloadclient,
+    getDownloadClientById: this.api.getApiV1DownloadclientById,
+    updateDownloadClientById: this.api.putApiV1DownloadclientById,
+    deleteDownloadClientById: this.api.deleteApiV1DownloadclientById,
+    getDownloadClientSchema: this.api.getApiV1DownloadclientSchema,
+    testDownloadClient: this.api.postApiV1DownloadclientTest,
+    testAllDownloadClients: this.api.postApiV1DownloadclientTestall,
 
     // Indexers
-    getIndexers: LidarrApi.getApiV1Indexer,
-    createIndexer: LidarrApi.postApiV1Indexer,
-    getIndexerById: LidarrApi.getApiV1IndexerById,
-    updateIndexerById: LidarrApi.putApiV1IndexerById,
-    deleteIndexerById: LidarrApi.deleteApiV1IndexerById,
-    getIndexerSchema: LidarrApi.getApiV1IndexerSchema,
-    testIndexer: LidarrApi.postApiV1IndexerTest,
-    testAllIndexers: LidarrApi.postApiV1IndexerTestall,
+    getIndexers: this.api.getApiV1Indexer,
+    createIndexer: this.api.postApiV1Indexer,
+    getIndexerById: this.api.getApiV1IndexerById,
+    updateIndexerById: this.api.putApiV1IndexerById,
+    deleteIndexerById: this.api.deleteApiV1IndexerById,
+    getIndexerSchema: this.api.getApiV1IndexerSchema,
+    testIndexer: this.api.postApiV1IndexerTest,
+    testAllIndexers: this.api.postApiV1IndexerTestall,
 
     // System Admin
-    restartSystem: LidarrApi.postApiV1SystemRestart,
-    shutdownSystem: LidarrApi.postApiV1SystemShutdown,
-    getBackups: LidarrApi.getApiV1SystemBackup,
-    deleteBackup: LidarrApi.deleteApiV1SystemBackupById,
-    restoreBackup: LidarrApi.postApiV1SystemBackupRestoreById,
-    uploadBackup: LidarrApi.postApiV1SystemBackupRestoreUpload,
-    getLogFiles: LidarrApi.getApiV1LogFile,
-    getLogFileByName: LidarrApi.getApiV1LogFileByFilename,
+    restartSystem: this.api.postApiV1SystemRestart,
+    shutdownSystem: this.api.postApiV1SystemShutdown,
+    getBackups: this.api.getApiV1SystemBackup,
+    deleteBackup: this.api.deleteApiV1SystemBackupById,
+    restoreBackup: this.api.postApiV1SystemBackupRestoreById,
+    uploadBackup: this.api.postApiV1SystemBackupRestoreUpload,
+    getLogFiles: this.api.getApiV1LogFile,
+    getLogFileByName: this.api.getApiV1LogFileByFilename,
 
     // Commands
-    runCommand: LidarrApi.postApiV1Command,
-    getCommands: LidarrApi.getApiV1Command,
+    runCommand: this.api.postApiV1Command,
+    getCommands: this.api.getApiV1Command,
 
     // Host Config
-    getHostConfig: LidarrApi.getApiV1ConfigHost,
-    getHostConfigById: LidarrApi.getApiV1ConfigHostById,
-    updateHostConfig: LidarrApi.putApiV1ConfigHostById,
+    getHostConfig: this.api.getApiV1ConfigHost,
+    getHostConfigById: this.api.getApiV1ConfigHostById,
+    updateHostConfig: this.api.putApiV1ConfigHostById,
 
     // UI Config
-    getUiConfig: LidarrApi.getApiV1ConfigUi,
-    getUiConfigById: LidarrApi.getApiV1ConfigUiById,
-    updateUiConfig: LidarrApi.putApiV1ConfigUiById,
+    getUiConfig: this.api.getApiV1ConfigUi,
+    getUiConfigById: this.api.getApiV1ConfigUiById,
+    updateUiConfig: this.api.putApiV1ConfigUiById,
   };
 
   constructor(config: ServarrClientConfig) {
-    super(config, lidarrClient);
+    super(config, createClient(createConfig({ baseUrl: 'http://localhost' })));
   }
 
   // Artist APIs
@@ -110,32 +114,32 @@ export class LidarrClient extends ServarrBaseClient {
    * Get all artists in the library
    */
   async getArtists() {
-    return LidarrApi.getApiV1Artist();
+    return this.api.getApiV1Artist();
   }
 
   async getArtist(id: number) {
-    return LidarrApi.getApiV1ArtistById({ path: { id } });
+    return this.api.getApiV1ArtistById({ path: { id } });
   }
 
   async addArtist(artist: ArtistResource) {
-    return LidarrApi.postApiV1Artist({ body: artist });
+    return this.api.postApiV1Artist({ body: artist });
   }
 
   async updateArtist(id: number, artist: ArtistResource) {
-    return LidarrApi.putApiV1ArtistById({ path: { id: String(id) }, body: artist });
+    return this.api.putApiV1ArtistById({ path: { id: String(id) }, body: artist });
   }
 
   async deleteArtist(id: number) {
-    return LidarrApi.deleteApiV1ArtistById({ path: { id } });
+    return this.api.deleteApiV1ArtistById({ path: { id } });
   }
 
   // Album APIs
   async getAlbums(artistId?: number) {
-    return LidarrApi.getApiV1Album(artistId === undefined ? {} : { query: { artistId } });
+    return this.api.getApiV1Album(artistId === undefined ? {} : { query: { artistId } });
   }
 
   async getAlbum(id: number) {
-    return LidarrApi.getApiV1AlbumById({ path: { id } });
+    return this.api.getApiV1AlbumById({ path: { id } });
   }
 
   // Search APIs
@@ -144,39 +148,39 @@ export class LidarrClient extends ServarrBaseClient {
    * Search for artists using MusicBrainz database
    */
   async searchArtists(term: string) {
-    return LidarrApi.getApiV1ArtistLookup({ query: { term } });
+    return this.api.getApiV1ArtistLookup({ query: { term } });
   }
 
   // Root folder APIs
   async getRootFolders() {
-    return LidarrApi.getApiV1Rootfolder();
+    return this.api.getApiV1Rootfolder();
   }
 
   async addRootFolder(path: string) {
-    return LidarrApi.postApiV1Rootfolder({
+    return this.api.postApiV1Rootfolder({
       body: { path },
     });
   }
 
   async deleteRootFolder(id: number) {
-    return LidarrApi.deleteApiV1RootfolderById({ path: { id } });
+    return this.api.deleteApiV1RootfolderById({ path: { id } });
   }
 
   // Album APIs (enhanced)
   async addAlbum(album: AlbumResource) {
-    return LidarrApi.postApiV1Album({ body: album });
+    return this.api.postApiV1Album({ body: album });
   }
 
   async updateAlbum(id: number, album: AlbumResource) {
-    return LidarrApi.putApiV1AlbumById({ path: { id: String(id) }, body: album });
+    return this.api.putApiV1AlbumById({ path: { id: String(id) }, body: album });
   }
 
   async deleteAlbum(id: number) {
-    return LidarrApi.deleteApiV1AlbumById({ path: { id } });
+    return this.api.deleteApiV1AlbumById({ path: { id } });
   }
 
   async searchAlbums(term: string) {
-    return LidarrApi.getApiV1AlbumLookup({ query: { term } });
+    return this.api.getApiV1AlbumLookup({ query: { term } });
   }
 
   // Calendar APIs
@@ -187,7 +191,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (unmonitored !== undefined) query.unmonitored = unmonitored;
     query.includeArtist = true;
 
-    return LidarrApi.getApiV1Calendar(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Calendar(Object.keys(query).length > 0 ? { query } : {});
   }
 
   async getCalendarFeed(pastDays?: number, futureDays?: number, tags?: string) {
@@ -196,7 +200,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (futureDays !== undefined) query.futureDays = futureDays;
     if (tags) query.tags = tags;
 
-    return LidarrApi.getFeedV1CalendarLidarrIcs(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getFeedV1CalendarLidarrIcs(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Track File APIs
@@ -216,109 +220,109 @@ export class LidarrClient extends ServarrBaseClient {
     if (albumId !== undefined) query.albumId = albumId;
     if (unmapped !== undefined) query.unmapped = unmapped;
 
-    return LidarrApi.getApiV1Trackfile(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Trackfile(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get a specific track file by ID
    */
   async getTrackFile(id: number) {
-    return LidarrApi.getApiV1TrackfileById({ path: { id } });
+    return this.api.getApiV1TrackfileById({ path: { id } });
   }
 
   /**
    * Update a track file
    */
   async updateTrackFile(id: string, trackFile: TrackFileResource) {
-    return LidarrApi.putApiV1TrackfileById({ path: { id }, body: trackFile });
+    return this.api.putApiV1TrackfileById({ path: { id }, body: trackFile });
   }
 
   /**
    * Delete a track file from disk
    */
   async deleteTrackFile(id: number) {
-    return LidarrApi.deleteApiV1TrackfileById({ path: { id } });
+    return this.api.deleteApiV1TrackfileById({ path: { id } });
   }
 
   /**
    * Bulk update track files using the editor endpoint
    */
   async updateTrackFilesEditor(trackFileList: TrackFileListResource) {
-    return LidarrApi.putApiV1TrackfileEditor({ body: trackFileList });
+    return this.api.putApiV1TrackfileEditor({ body: trackFileList });
   }
 
   /**
    * Bulk delete track files
    */
   async deleteTrackFilesBulk(trackFileList: TrackFileListResource) {
-    return LidarrApi.deleteApiV1TrackfileBulk({ body: trackFileList });
+    return this.api.deleteApiV1TrackfileBulk({ body: trackFileList });
   }
 
   // Quality Profile APIs
   async getQualityProfiles() {
-    return LidarrApi.getApiV1Qualityprofile();
+    return this.api.getApiV1Qualityprofile();
   }
 
   async getQualityProfile(id: number) {
-    return LidarrApi.getApiV1QualityprofileById({ path: { id } });
+    return this.api.getApiV1QualityprofileById({ path: { id } });
   }
 
   async addQualityProfile(profile: QualityProfileResource) {
-    return LidarrApi.postApiV1Qualityprofile({ body: profile });
+    return this.api.postApiV1Qualityprofile({ body: profile });
   }
 
   async updateQualityProfile(id: number, profile: QualityProfileResource) {
-    return LidarrApi.putApiV1QualityprofileById({ path: { id: String(id) }, body: profile });
+    return this.api.putApiV1QualityprofileById({ path: { id: String(id) }, body: profile });
   }
 
   async deleteQualityProfile(id: number) {
-    return LidarrApi.deleteApiV1QualityprofileById({ path: { id } });
+    return this.api.deleteApiV1QualityprofileById({ path: { id } });
   }
 
   async getQualityProfileSchema() {
-    return LidarrApi.getApiV1QualityprofileSchema();
+    return this.api.getApiV1QualityprofileSchema();
   }
 
   // Metadata Profile APIs
   async getMetadataProfiles() {
-    return LidarrApi.getApiV1Metadataprofile();
+    return this.api.getApiV1Metadataprofile();
   }
 
   async getMetadataProfile(id: number) {
-    return LidarrApi.getApiV1MetadataprofileById({ path: { id } });
+    return this.api.getApiV1MetadataprofileById({ path: { id } });
   }
 
   // Custom Format APIs
   async getCustomFormats() {
-    return LidarrApi.getApiV1Customformat();
+    return this.api.getApiV1Customformat();
   }
 
   async getCustomFormat(id: number) {
-    return LidarrApi.getApiV1CustomformatById({ path: { id } });
+    return this.api.getApiV1CustomformatById({ path: { id } });
   }
 
   async addCustomFormat(format: CustomFormatResource) {
-    return LidarrApi.postApiV1Customformat({ body: format });
+    return this.api.postApiV1Customformat({ body: format });
   }
 
   async updateCustomFormat(id: number, format: CustomFormatResource) {
-    return LidarrApi.putApiV1CustomformatById({ path: { id: String(id) }, body: format });
+    return this.api.putApiV1CustomformatById({ path: { id: String(id) }, body: format });
   }
 
   async deleteCustomFormat(id: number) {
-    return LidarrApi.deleteApiV1CustomformatById({ path: { id } });
+    return this.api.deleteApiV1CustomformatById({ path: { id } });
   }
 
   async updateCustomFormatsBulk(formats: CustomFormatBulkResource) {
-    return LidarrApi.putApiV1CustomformatBulk({ body: formats });
+    return this.api.putApiV1CustomformatBulk({ body: formats });
   }
 
   async deleteCustomFormatsBulk(ids: number[]) {
-    return LidarrApi.deleteApiV1CustomformatBulk({ body: { ids } });
+    return this.api.deleteApiV1CustomformatBulk({ body: { ids } });
   }
 
   async getCustomFormatSchema() {
-    return LidarrApi.getApiV1CustomformatSchema();
+    return this.api.getApiV1CustomformatSchema();
   }
 
   // Configuration Management APIs
@@ -327,84 +331,84 @@ export class LidarrClient extends ServarrBaseClient {
    * Get naming configuration settings
    */
   async getNamingConfig() {
-    return LidarrApi.getApiV1ConfigNaming();
+    return this.api.getApiV1ConfigNaming();
   }
 
   /**
    * Get naming configuration by ID
    */
   async getNamingConfigById(id: number) {
-    return LidarrApi.getApiV1ConfigNamingById({ path: { id } });
+    return this.api.getApiV1ConfigNamingById({ path: { id } });
   }
 
   /**
    * Update naming configuration
    */
   async updateNamingConfig(id: number, config: NamingConfigResource) {
-    return LidarrApi.putApiV1ConfigNamingById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigNamingById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get naming configuration examples
    */
   async getNamingConfigExamples() {
-    return LidarrApi.getApiV1ConfigNamingExamples();
+    return this.api.getApiV1ConfigNamingExamples();
   }
 
   /**
    * Get media management configuration settings
    */
   async getMediaManagementConfig() {
-    return LidarrApi.getApiV1ConfigMediamanagement();
+    return this.api.getApiV1ConfigMediamanagement();
   }
 
   /**
    * Get media management configuration by ID
    */
   async getMediaManagementConfigById(id: number) {
-    return LidarrApi.getApiV1ConfigMediamanagementById({ path: { id } });
+    return this.api.getApiV1ConfigMediamanagementById({ path: { id } });
   }
 
   /**
    * Update media management configuration
    */
   async updateMediaManagementConfig(id: number, config: MediaManagementConfigResource) {
-    return LidarrApi.putApiV1ConfigMediamanagementById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigMediamanagementById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get metadata provider configuration settings
    */
   async getMetadataProviderConfig() {
-    return LidarrApi.getApiV1ConfigMetadataprovider();
+    return this.api.getApiV1ConfigMetadataprovider();
   }
 
   /**
    * Get metadata provider configuration by ID
    */
   async getMetadataProviderConfigById(id: number) {
-    return LidarrApi.getApiV1ConfigMetadataproviderById({ path: { id } });
+    return this.api.getApiV1ConfigMetadataproviderById({ path: { id } });
   }
 
   /**
    * Update metadata provider configuration
    */
   async updateMetadataProviderConfig(id: number, config: MetadataProviderConfigResource) {
-    return LidarrApi.putApiV1ConfigMetadataproviderById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigMetadataproviderById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get system logs
    */
   async getSystemLogs() {
-    return LidarrApi.getApiV1Log();
+    return this.api.getApiV1Log();
   }
 
   /**
    * Get disk space information
    */
   async getDiskSpace() {
-    return LidarrApi.getApiV1Diskspace();
+    return this.api.getApiV1Diskspace();
   }
 
   // Release APIs
@@ -417,14 +421,14 @@ export class LidarrClient extends ServarrBaseClient {
     if (albumId !== undefined) query.albumId = albumId;
     if (artistId !== undefined) query.artistId = artistId;
 
-    return LidarrApi.getApiV1Release(Object.keys(query).length === 0 ? {} : { query });
+    return this.api.getApiV1Release(Object.keys(query).length === 0 ? {} : { query });
   }
 
   /**
    * Grab a complete release candidate returned by getRelease
    */
   async addRelease(release: ReleaseResource) {
-    return LidarrApi.postApiV1Release({ body: release });
+    return this.api.postApiV1Release({ body: release });
   }
 
   // Import List APIs
@@ -433,56 +437,56 @@ export class LidarrClient extends ServarrBaseClient {
    * Get all import lists
    */
   async getImportLists() {
-    return LidarrApi.getApiV1Importlist();
+    return this.api.getApiV1Importlist();
   }
 
   /**
    * Get a specific import list by ID
    */
   async getImportList(id: number) {
-    return LidarrApi.getApiV1ImportlistById({ path: { id } });
+    return this.api.getApiV1ImportlistById({ path: { id } });
   }
 
   /**
    * Add a new import list
    */
   async addImportList(importList: ImportListResource) {
-    return LidarrApi.postApiV1Importlist({ body: importList });
+    return this.api.postApiV1Importlist({ body: importList });
   }
 
   /**
    * Update an existing import list
    */
   async updateImportList(id: number, importList: ImportListResource) {
-    return LidarrApi.putApiV1ImportlistById({ path: { id }, body: importList });
+    return this.api.putApiV1ImportlistById({ path: { id }, body: importList });
   }
 
   /**
    * Delete an import list
    */
   async deleteImportList(id: number) {
-    return LidarrApi.deleteApiV1ImportlistById({ path: { id } });
+    return this.api.deleteApiV1ImportlistById({ path: { id } });
   }
 
   /**
    * Get import list schema for available list types
    */
   async getImportListSchema() {
-    return LidarrApi.getApiV1ImportlistSchema();
+    return this.api.getApiV1ImportlistSchema();
   }
 
   /**
    * Test an import list configuration
    */
   async testImportList(importList: ImportListResource) {
-    return LidarrApi.postApiV1ImportlistTest({ body: importList });
+    return this.api.postApiV1ImportlistTest({ body: importList });
   }
 
   /**
    * Test all import lists
    */
   async testAllImportLists() {
-    return LidarrApi.postApiV1ImportlistTestall();
+    return this.api.postApiV1ImportlistTestall();
   }
 
   // History APIs
@@ -506,7 +510,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (artistId !== undefined) query.artistId = artistId;
     if (downloadId) query.downloadId = downloadId;
 
-    return LidarrApi.getApiV1History(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1History(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -516,7 +520,7 @@ export class LidarrClient extends ServarrBaseClient {
     const query: any = { date };
     if (artistId !== undefined) query.artistId = artistId;
 
-    return LidarrApi.getApiV1HistorySince({ query });
+    return this.api.getApiV1HistorySince({ query });
   }
 
   /**
@@ -526,14 +530,14 @@ export class LidarrClient extends ServarrBaseClient {
     const query: any = { artistId };
     if (eventType !== undefined) query.eventType = eventType;
 
-    return LidarrApi.getApiV1HistoryArtist({ query });
+    return this.api.getApiV1HistoryArtist({ query });
   }
 
   /**
    * Mark a failed download as failed in history
    */
   async markHistoryItemFailed(id: number) {
-    return LidarrApi.postApiV1HistoryFailedById({ path: { id } });
+    return this.api.postApiV1HistoryFailedById({ path: { id } });
   }
 
   // Queue APIs
@@ -556,7 +560,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (includeUnknownArtistItems !== undefined)
       query.includeUnknownArtistItems = includeUnknownArtistItems;
 
-    return LidarrApi.getApiV1Queue(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Queue(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -567,7 +571,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return LidarrApi.deleteApiV1QueueById({
+    return this.api.deleteApiV1QueueById({
       path: { id },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -581,7 +585,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return LidarrApi.deleteApiV1QueueBulk({
+    return this.api.deleteApiV1QueueBulk({
       body: { ids },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -591,14 +595,14 @@ export class LidarrClient extends ServarrBaseClient {
    * Force grab a queue item
    */
   async grabQueueItem(id: number) {
-    return LidarrApi.postApiV1QueueGrabById({ path: { id } });
+    return this.api.postApiV1QueueGrabById({ path: { id } });
   }
 
   /**
    * Force grab multiple queue items
    */
   async grabQueueItemsBulk(ids: number[]) {
-    return LidarrApi.postApiV1QueueGrabBulk({ body: { ids } });
+    return this.api.postApiV1QueueGrabBulk({ body: { ids } });
   }
 
   /**
@@ -610,14 +614,14 @@ export class LidarrClient extends ServarrBaseClient {
     if (includeUnknownArtistItems !== undefined)
       query.includeUnknownArtistItems = includeUnknownArtistItems;
 
-    return LidarrApi.getApiV1QueueDetails(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1QueueDetails(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get queue status summary
    */
   async getQueueStatus() {
-    return LidarrApi.getApiV1QueueStatus();
+    return this.api.getApiV1QueueStatus();
   }
 
   // Blocklist APIs
@@ -632,21 +636,21 @@ export class LidarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return LidarrApi.getApiV1Blocklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Blocklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Remove a release from the blocklist
    */
   async removeBlocklistItem(id: number) {
-    return LidarrApi.deleteApiV1BlocklistById({ path: { id } });
+    return this.api.deleteApiV1BlocklistById({ path: { id } });
   }
 
   /**
    * Bulk remove releases from the blocklist
    */
   async removeBlocklistItemsBulk(ids: number[]) {
-    return LidarrApi.deleteApiV1BlocklistBulk({ body: { ids } });
+    return this.api.deleteApiV1BlocklistBulk({ body: { ids } });
   }
 
   /**
@@ -666,7 +670,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (sortDirection) query.sortDirection = sortDirection;
     if (monitored !== undefined) query.monitored = monitored;
 
-    return LidarrApi.getApiV1WantedMissing(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1WantedMissing(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -686,7 +690,7 @@ export class LidarrClient extends ServarrBaseClient {
     if (sortDirection) query.sortDirection = sortDirection;
     if (monitored !== undefined) query.monitored = monitored;
 
-    return LidarrApi.getApiV1WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
   }
 }
 

--- a/src/clients/prowlarr.ts
+++ b/src/clients/prowlarr.ts
@@ -1,6 +1,7 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import { bindApiClient } from '../core/bind-api';
 import type { ServarrClientConfig } from '../core/types';
-import { client as prowlarrClient } from '../generated/prowlarr/client.gen';
+import { createClient, createConfig } from '../generated/prowlarr/client';
 import * as ProwlarrApi from '../generated/prowlarr/index';
 import type {
   ApplicationResource,
@@ -21,77 +22,80 @@ import type {
  * ```
  */
 export class ProwlarrClient extends ServarrBaseClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly api = bindApiClient(ProwlarrApi, this.rawClient);
+
   protected readonly ops: ServarrOps = {
     // System
-    getSystemStatus: ProwlarrApi.getApiV1SystemStatus,
-    getHealth: ProwlarrApi.getApiV1Health,
+    getSystemStatus: this.api.getApiV1SystemStatus,
+    getHealth: this.api.getApiV1Health,
 
     // Tags
-    getTags: ProwlarrApi.getApiV1Tag,
-    createTag: ProwlarrApi.postApiV1Tag,
-    getTagById: ProwlarrApi.getApiV1TagById,
-    updateTagById: ProwlarrApi.putApiV1TagById,
-    deleteTagById: ProwlarrApi.deleteApiV1TagById,
-    getTagDetails: ProwlarrApi.getApiV1TagDetail,
-    getTagDetailById: ProwlarrApi.getApiV1TagDetailById,
+    getTags: this.api.getApiV1Tag,
+    createTag: this.api.postApiV1Tag,
+    getTagById: this.api.getApiV1TagById,
+    updateTagById: this.api.putApiV1TagById,
+    deleteTagById: this.api.deleteApiV1TagById,
+    getTagDetails: this.api.getApiV1TagDetail,
+    getTagDetailById: this.api.getApiV1TagDetailById,
 
     // Notifications
-    getNotifications: ProwlarrApi.getApiV1Notification,
-    createNotification: ProwlarrApi.postApiV1Notification,
-    getNotificationById: ProwlarrApi.getApiV1NotificationById,
-    updateNotificationById: ProwlarrApi.putApiV1NotificationById,
-    deleteNotificationById: ProwlarrApi.deleteApiV1NotificationById,
-    getNotificationSchema: ProwlarrApi.getApiV1NotificationSchema,
-    testNotification: ProwlarrApi.postApiV1NotificationTest,
-    testAllNotifications: ProwlarrApi.postApiV1NotificationTestall,
+    getNotifications: this.api.getApiV1Notification,
+    createNotification: this.api.postApiV1Notification,
+    getNotificationById: this.api.getApiV1NotificationById,
+    updateNotificationById: this.api.putApiV1NotificationById,
+    deleteNotificationById: this.api.deleteApiV1NotificationById,
+    getNotificationSchema: this.api.getApiV1NotificationSchema,
+    testNotification: this.api.postApiV1NotificationTest,
+    testAllNotifications: this.api.postApiV1NotificationTestall,
 
     // Download Clients
-    getDownloadClients: ProwlarrApi.getApiV1Downloadclient,
-    createDownloadClient: ProwlarrApi.postApiV1Downloadclient,
-    getDownloadClientById: ProwlarrApi.getApiV1DownloadclientById,
-    updateDownloadClientById: ProwlarrApi.putApiV1DownloadclientById,
-    deleteDownloadClientById: ProwlarrApi.deleteApiV1DownloadclientById,
-    getDownloadClientSchema: ProwlarrApi.getApiV1DownloadclientSchema,
-    testDownloadClient: ProwlarrApi.postApiV1DownloadclientTest,
-    testAllDownloadClients: ProwlarrApi.postApiV1DownloadclientTestall,
+    getDownloadClients: this.api.getApiV1Downloadclient,
+    createDownloadClient: this.api.postApiV1Downloadclient,
+    getDownloadClientById: this.api.getApiV1DownloadclientById,
+    updateDownloadClientById: this.api.putApiV1DownloadclientById,
+    deleteDownloadClientById: this.api.deleteApiV1DownloadclientById,
+    getDownloadClientSchema: this.api.getApiV1DownloadclientSchema,
+    testDownloadClient: this.api.postApiV1DownloadclientTest,
+    testAllDownloadClients: this.api.postApiV1DownloadclientTestall,
 
     // Indexers
-    getIndexers: ProwlarrApi.getApiV1Indexer,
-    createIndexer: ProwlarrApi.postApiV1Indexer,
-    getIndexerById: ProwlarrApi.getApiV1IndexerById,
-    updateIndexerById: ProwlarrApi.putApiV1IndexerById,
-    deleteIndexerById: ProwlarrApi.deleteApiV1IndexerById,
-    getIndexerSchema: ProwlarrApi.getApiV1IndexerSchema,
-    testIndexer: ProwlarrApi.postApiV1IndexerTest,
-    testAllIndexers: ProwlarrApi.postApiV1IndexerTestall,
+    getIndexers: this.api.getApiV1Indexer,
+    createIndexer: this.api.postApiV1Indexer,
+    getIndexerById: this.api.getApiV1IndexerById,
+    updateIndexerById: this.api.putApiV1IndexerById,
+    deleteIndexerById: this.api.deleteApiV1IndexerById,
+    getIndexerSchema: this.api.getApiV1IndexerSchema,
+    testIndexer: this.api.postApiV1IndexerTest,
+    testAllIndexers: this.api.postApiV1IndexerTestall,
 
     // System Admin
-    restartSystem: ProwlarrApi.postApiV1SystemRestart,
-    shutdownSystem: ProwlarrApi.postApiV1SystemShutdown,
-    getBackups: ProwlarrApi.getApiV1SystemBackup,
-    deleteBackup: ProwlarrApi.deleteApiV1SystemBackupById,
-    restoreBackup: ProwlarrApi.postApiV1SystemBackupRestoreById,
-    uploadBackup: ProwlarrApi.postApiV1SystemBackupRestoreUpload,
-    getLogFiles: ProwlarrApi.getApiV1LogFile,
-    getLogFileByName: ProwlarrApi.getApiV1LogFileByFilename,
+    restartSystem: this.api.postApiV1SystemRestart,
+    shutdownSystem: this.api.postApiV1SystemShutdown,
+    getBackups: this.api.getApiV1SystemBackup,
+    deleteBackup: this.api.deleteApiV1SystemBackupById,
+    restoreBackup: this.api.postApiV1SystemBackupRestoreById,
+    uploadBackup: this.api.postApiV1SystemBackupRestoreUpload,
+    getLogFiles: this.api.getApiV1LogFile,
+    getLogFileByName: this.api.getApiV1LogFileByFilename,
 
     // Commands
-    runCommand: ProwlarrApi.postApiV1Command,
-    getCommands: ProwlarrApi.getApiV1Command,
+    runCommand: this.api.postApiV1Command,
+    getCommands: this.api.getApiV1Command,
 
     // Host Config
-    getHostConfig: ProwlarrApi.getApiV1ConfigHost,
-    getHostConfigById: ProwlarrApi.getApiV1ConfigHostById,
-    updateHostConfig: ProwlarrApi.putApiV1ConfigHostById,
+    getHostConfig: this.api.getApiV1ConfigHost,
+    getHostConfigById: this.api.getApiV1ConfigHostById,
+    updateHostConfig: this.api.putApiV1ConfigHostById,
 
     // UI Config
-    getUiConfig: ProwlarrApi.getApiV1ConfigUi,
-    getUiConfigById: ProwlarrApi.getApiV1ConfigUiById,
-    updateUiConfig: ProwlarrApi.putApiV1ConfigUiById,
+    getUiConfig: this.api.getApiV1ConfigUi,
+    getUiConfigById: this.api.getApiV1ConfigUiById,
+    updateUiConfig: this.api.putApiV1ConfigUiById,
   };
 
   constructor(config: ServarrClientConfig) {
-    super(config, prowlarrClient);
+    super(config, createClient(createConfig({ baseUrl: 'http://localhost' })));
   }
 
   // Prowlarr-specific APIs
@@ -102,7 +106,7 @@ export class ProwlarrClient extends ServarrBaseClient {
    * Get indexer statistics
    */
   async getIndexerStats() {
-    return ProwlarrApi.getApiV1Indexerstats();
+    return this.api.getApiV1Indexerstats();
   }
 
   // Search APIs
@@ -111,7 +115,7 @@ export class ProwlarrClient extends ServarrBaseClient {
    * Search across all or specific indexers
    */
   async search(query: string, indexerIds?: number[]) {
-    return ProwlarrApi.getApiV1Search({
+    return this.api.getApiV1Search({
       query: {
         query,
         ...(indexerIds && { indexerIds }),
@@ -125,56 +129,56 @@ export class ProwlarrClient extends ServarrBaseClient {
    * Get all applications
    */
   async getApplications() {
-    return ProwlarrApi.getApiV1Applications();
+    return this.api.getApiV1Applications();
   }
 
   /**
    * Get a specific application by ID
    */
   async getApplication(id: number) {
-    return ProwlarrApi.getApiV1ApplicationsById({ path: { id } });
+    return this.api.getApiV1ApplicationsById({ path: { id } });
   }
 
   /**
    * Add a new application
    */
   async addApplication(application: ApplicationResource) {
-    return ProwlarrApi.postApiV1Applications({ body: application });
+    return this.api.postApiV1Applications({ body: application });
   }
 
   /**
    * Update an existing application
    */
   async updateApplication(id: number, application: ApplicationResource) {
-    return ProwlarrApi.putApiV1ApplicationsById({ path: { id: String(id) }, body: application });
+    return this.api.putApiV1ApplicationsById({ path: { id: String(id) }, body: application });
   }
 
   /**
    * Delete an application
    */
   async deleteApplication(id: number) {
-    return ProwlarrApi.deleteApiV1ApplicationsById({ path: { id } });
+    return this.api.deleteApiV1ApplicationsById({ path: { id } });
   }
 
   /**
    * Test an application configuration
    */
   async testApplication(application: ApplicationResource) {
-    return ProwlarrApi.postApiV1ApplicationsTest({ body: application });
+    return this.api.postApiV1ApplicationsTest({ body: application });
   }
 
   /**
    * Test all applications
    */
   async testAllApplications() {
-    return ProwlarrApi.postApiV1ApplicationsTestall();
+    return this.api.postApiV1ApplicationsTestall();
   }
 
   /**
    * Get application schema for available application types
    */
   async getApplicationSchema() {
-    return ProwlarrApi.getApiV1ApplicationsSchema();
+    return this.api.getApiV1ApplicationsSchema();
   }
 
   // Development Configuration APIs
@@ -183,21 +187,21 @@ export class ProwlarrClient extends ServarrBaseClient {
    * Get development configuration settings
    */
   async getDevelopmentConfig() {
-    return ProwlarrApi.getApiV1ConfigDevelopment();
+    return this.api.getApiV1ConfigDevelopment();
   }
 
   /**
    * Get development configuration by ID
    */
   async getDevelopmentConfigById(id: number) {
-    return ProwlarrApi.getApiV1ConfigDevelopmentById({ path: { id } });
+    return this.api.getApiV1ConfigDevelopmentById({ path: { id } });
   }
 
   /**
    * Update development configuration
    */
   async updateDevelopmentConfig(id: number, config: DevelopmentConfigResource) {
-    return ProwlarrApi.putApiV1ConfigDevelopmentById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigDevelopmentById({ path: { id: String(id) }, body: config });
   }
 
   // System Logs API
@@ -206,7 +210,7 @@ export class ProwlarrClient extends ServarrBaseClient {
    * Get system logs
    */
   async getSystemLogs() {
-    return ProwlarrApi.getApiV1Log();
+    return this.api.getApiV1Log();
   }
 }
 

--- a/src/clients/qbittorrent.ts
+++ b/src/clients/qbittorrent.ts
@@ -1,7 +1,8 @@
+import { bindApiClient } from '../core/bind-api';
 import { ConnectionError } from '../core/errors';
 import { createResilientFetch } from '../core/fetch';
 import type { QBittorrentClientConfig } from '../core/types';
-import { client as qbittorrentClient } from '../generated/qbittorrent/client.gen';
+import { createClient, createConfig } from '../generated/qbittorrent/client';
 import * as QBittorrentApi from '../generated/qbittorrent/index';
 import type {
   TorrentInfo,
@@ -30,6 +31,9 @@ type TorrentFilter = NonNullable<TorrentsInfoPostData['body']['filter']>;
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export class QBittorrentClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly rawClient = createClient(createConfig({ baseUrl: 'http://localhost' }));
+  private readonly api = bindApiClient(QBittorrentApi, this.rawClient);
   private baseUrl: string;
   private username: string;
   private password: string;
@@ -55,7 +59,7 @@ export class QBittorrentClient {
     this.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
       this.fetchWithCookieName(baseFetch, input, init)) as typeof globalThis.fetch;
 
-    qbittorrentClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: `${this.baseUrl}/api/v2`,
       auth: () => this.ensureAuth(),
       fetch: this.fetch,
@@ -136,12 +140,12 @@ export class QBittorrentClient {
   // App APIs
 
   async getAppVersion(): Promise<string> {
-    const result = await QBittorrentApi.appVersionGet();
+    const result = await this.api.appVersionGet();
     return (result.data as string) ?? '';
   }
 
   async getApiVersion(): Promise<string> {
-    const result = await QBittorrentApi.appWebapiVersionGet();
+    const result = await this.api.appWebapiVersionGet();
     return (result.data as string) ?? '';
   }
 
@@ -153,14 +157,14 @@ export class QBittorrentClient {
   // Transfer APIs
 
   async getTransferInfo(): Promise<TransferInfo> {
-    const result = await QBittorrentApi.transferInfoGet();
+    const result = await this.api.transferInfoGet();
     return (result.data as TransferInfo) ?? {};
   }
 
   // Torrent APIs
 
   async getTorrents(filter?: TorrentFilter): Promise<TorrentInfo[]> {
-    const result = await QBittorrentApi.torrentsInfoPost({
+    const result = await this.api.torrentsInfoPost({
       body: {
         ...(filter ? { filter } : {}),
       },
@@ -169,19 +173,19 @@ export class QBittorrentClient {
   }
 
   async pauseTorrents(hashes: string): Promise<void> {
-    await QBittorrentApi.torrentsPausePost({
+    await this.api.torrentsPausePost({
       body: { hashes: hashes.split('|') },
     });
   }
 
   async resumeTorrents(hashes: string): Promise<void> {
-    await QBittorrentApi.torrentsResumePost({
+    await this.api.torrentsResumePost({
       body: { hashes: hashes.split('|') },
     });
   }
 
   async deleteTorrents(hashes: string, deleteFiles = false): Promise<void> {
-    await QBittorrentApi.torrentsDeletePost({
+    await this.api.torrentsDeletePost({
       body: { hashes: hashes.split('|'), deleteFiles },
     });
   }

--- a/src/clients/radarr.ts
+++ b/src/clients/radarr.ts
@@ -1,6 +1,7 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import { bindApiClient } from '../core/bind-api';
 import type { ServarrClientConfig } from '../core/types';
-import { client as radarrClient } from '../generated/radarr/client.gen';
+import { createClient, createConfig } from '../generated/radarr/client';
 import * as RadarrApi from '../generated/radarr/index';
 import type {
   CustomFormatBulkResource,
@@ -26,77 +27,80 @@ export type ManualImportFilePayload = {
 };
 
 export class RadarrClient extends ServarrBaseClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly api = bindApiClient(RadarrApi, this.rawClient);
+
   protected readonly ops: ServarrOps = {
     // System
-    getSystemStatus: RadarrApi.getApiV3SystemStatus,
-    getHealth: RadarrApi.getApiV3Health,
+    getSystemStatus: this.api.getApiV3SystemStatus,
+    getHealth: this.api.getApiV3Health,
 
     // Tags
-    getTags: RadarrApi.getApiV3Tag,
-    createTag: RadarrApi.postApiV3Tag,
-    getTagById: RadarrApi.getApiV3TagById,
-    updateTagById: RadarrApi.putApiV3TagById,
-    deleteTagById: RadarrApi.deleteApiV3TagById,
-    getTagDetails: RadarrApi.getApiV3TagDetail,
-    getTagDetailById: RadarrApi.getApiV3TagDetailById,
+    getTags: this.api.getApiV3Tag,
+    createTag: this.api.postApiV3Tag,
+    getTagById: this.api.getApiV3TagById,
+    updateTagById: this.api.putApiV3TagById,
+    deleteTagById: this.api.deleteApiV3TagById,
+    getTagDetails: this.api.getApiV3TagDetail,
+    getTagDetailById: this.api.getApiV3TagDetailById,
 
     // Notifications
-    getNotifications: RadarrApi.getApiV3Notification,
-    createNotification: RadarrApi.postApiV3Notification,
-    getNotificationById: RadarrApi.getApiV3NotificationById,
-    updateNotificationById: RadarrApi.putApiV3NotificationById,
-    deleteNotificationById: RadarrApi.deleteApiV3NotificationById,
-    getNotificationSchema: RadarrApi.getApiV3NotificationSchema,
-    testNotification: RadarrApi.postApiV3NotificationTest,
-    testAllNotifications: RadarrApi.postApiV3NotificationTestall,
+    getNotifications: this.api.getApiV3Notification,
+    createNotification: this.api.postApiV3Notification,
+    getNotificationById: this.api.getApiV3NotificationById,
+    updateNotificationById: this.api.putApiV3NotificationById,
+    deleteNotificationById: this.api.deleteApiV3NotificationById,
+    getNotificationSchema: this.api.getApiV3NotificationSchema,
+    testNotification: this.api.postApiV3NotificationTest,
+    testAllNotifications: this.api.postApiV3NotificationTestall,
 
     // Download Clients
-    getDownloadClients: RadarrApi.getApiV3Downloadclient,
-    createDownloadClient: RadarrApi.postApiV3Downloadclient,
-    getDownloadClientById: RadarrApi.getApiV3DownloadclientById,
-    updateDownloadClientById: RadarrApi.putApiV3DownloadclientById,
-    deleteDownloadClientById: RadarrApi.deleteApiV3DownloadclientById,
-    getDownloadClientSchema: RadarrApi.getApiV3DownloadclientSchema,
-    testDownloadClient: RadarrApi.postApiV3DownloadclientTest,
-    testAllDownloadClients: RadarrApi.postApiV3DownloadclientTestall,
+    getDownloadClients: this.api.getApiV3Downloadclient,
+    createDownloadClient: this.api.postApiV3Downloadclient,
+    getDownloadClientById: this.api.getApiV3DownloadclientById,
+    updateDownloadClientById: this.api.putApiV3DownloadclientById,
+    deleteDownloadClientById: this.api.deleteApiV3DownloadclientById,
+    getDownloadClientSchema: this.api.getApiV3DownloadclientSchema,
+    testDownloadClient: this.api.postApiV3DownloadclientTest,
+    testAllDownloadClients: this.api.postApiV3DownloadclientTestall,
 
     // Indexers
-    getIndexers: RadarrApi.getApiV3Indexer,
-    createIndexer: RadarrApi.postApiV3Indexer,
-    getIndexerById: RadarrApi.getApiV3IndexerById,
-    updateIndexerById: RadarrApi.putApiV3IndexerById,
-    deleteIndexerById: RadarrApi.deleteApiV3IndexerById,
-    getIndexerSchema: RadarrApi.getApiV3IndexerSchema,
-    testIndexer: RadarrApi.postApiV3IndexerTest,
-    testAllIndexers: RadarrApi.postApiV3IndexerTestall,
+    getIndexers: this.api.getApiV3Indexer,
+    createIndexer: this.api.postApiV3Indexer,
+    getIndexerById: this.api.getApiV3IndexerById,
+    updateIndexerById: this.api.putApiV3IndexerById,
+    deleteIndexerById: this.api.deleteApiV3IndexerById,
+    getIndexerSchema: this.api.getApiV3IndexerSchema,
+    testIndexer: this.api.postApiV3IndexerTest,
+    testAllIndexers: this.api.postApiV3IndexerTestall,
 
     // System Admin
-    restartSystem: RadarrApi.postApiV3SystemRestart,
-    shutdownSystem: RadarrApi.postApiV3SystemShutdown,
-    getBackups: RadarrApi.getApiV3SystemBackup,
-    deleteBackup: RadarrApi.deleteApiV3SystemBackupById,
-    restoreBackup: RadarrApi.postApiV3SystemBackupRestoreById,
-    uploadBackup: RadarrApi.postApiV3SystemBackupRestoreUpload,
-    getLogFiles: RadarrApi.getApiV3LogFile,
-    getLogFileByName: RadarrApi.getApiV3LogFileByFilename,
+    restartSystem: this.api.postApiV3SystemRestart,
+    shutdownSystem: this.api.postApiV3SystemShutdown,
+    getBackups: this.api.getApiV3SystemBackup,
+    deleteBackup: this.api.deleteApiV3SystemBackupById,
+    restoreBackup: this.api.postApiV3SystemBackupRestoreById,
+    uploadBackup: this.api.postApiV3SystemBackupRestoreUpload,
+    getLogFiles: this.api.getApiV3LogFile,
+    getLogFileByName: this.api.getApiV3LogFileByFilename,
 
     // Commands
-    runCommand: RadarrApi.postApiV3Command,
-    getCommands: RadarrApi.getApiV3Command,
+    runCommand: this.api.postApiV3Command,
+    getCommands: this.api.getApiV3Command,
 
     // Host Config
-    getHostConfig: RadarrApi.getApiV3ConfigHost,
-    getHostConfigById: RadarrApi.getApiV3ConfigHostById,
-    updateHostConfig: RadarrApi.putApiV3ConfigHostById,
+    getHostConfig: this.api.getApiV3ConfigHost,
+    getHostConfigById: this.api.getApiV3ConfigHostById,
+    updateHostConfig: this.api.putApiV3ConfigHostById,
 
     // UI Config
-    getUiConfig: RadarrApi.getApiV3ConfigUi,
-    getUiConfigById: RadarrApi.getApiV3ConfigUiById,
-    updateUiConfig: RadarrApi.putApiV3ConfigUiById,
+    getUiConfig: this.api.getApiV3ConfigUi,
+    getUiConfigById: this.api.getApiV3ConfigUiById,
+    updateUiConfig: this.api.putApiV3ConfigUiById,
   };
 
   constructor(config: ServarrClientConfig) {
-    super(config, radarrClient);
+    super(config, createClient(createConfig({ baseUrl: 'http://localhost' })));
   }
 
   // Movie APIs
@@ -105,29 +109,29 @@ export class RadarrClient extends ServarrBaseClient {
    * Get all movies in the library
    */
   async getMovies() {
-    return RadarrApi.getApiV3Movie();
+    return this.api.getApiV3Movie();
   }
 
   /**
    * Get a specific movie by ID
    */
   async getMovie(id: number) {
-    return RadarrApi.getApiV3MovieById({ path: { id } });
+    return this.api.getApiV3MovieById({ path: { id } });
   }
 
   /**
    * Add a new movie to the library
    */
   async addMovie(movie: MovieResource) {
-    return RadarrApi.postApiV3Movie({ body: movie });
+    return this.api.postApiV3Movie({ body: movie });
   }
 
   async updateMovie(id: number, movie: MovieResource) {
-    return RadarrApi.putApiV3MovieById({ path: { id: String(id) }, body: movie });
+    return this.api.putApiV3MovieById({ path: { id: String(id) }, body: movie });
   }
 
   async deleteMovie(id: number, options?: { deleteFiles?: boolean; addImportExclusion?: boolean }) {
-    return RadarrApi.deleteApiV3MovieById({
+    return this.api.deleteApiV3MovieById({
       path: { id },
       ...(options ? { query: options } : {}),
     });
@@ -139,7 +143,7 @@ export class RadarrClient extends ServarrBaseClient {
    * Search for movies using TMDB database
    */
   async searchMovies(term: string) {
-    return RadarrApi.getApiV3MovieLookup({ query: { term } });
+    return this.api.getApiV3MovieLookup({ query: { term } });
   }
 
   /**
@@ -148,7 +152,7 @@ export class RadarrClient extends ServarrBaseClient {
    * @returns Movie details from TMDB
    */
   async lookupMovieByTmdbId(tmdbId: number) {
-    return RadarrApi.getApiV3MovieLookupTmdb({ query: { tmdbId } });
+    return this.api.getApiV3MovieLookupTmdb({ query: { tmdbId } });
   }
 
   /**
@@ -157,7 +161,7 @@ export class RadarrClient extends ServarrBaseClient {
    * @returns Movie details from IMDB
    */
   async lookupMovieByImdbId(imdbId: string) {
-    return RadarrApi.getApiV3MovieLookupImdb({ query: { imdbId } });
+    return this.api.getApiV3MovieLookupImdb({ query: { imdbId } });
   }
 
   /**
@@ -211,7 +215,7 @@ export class RadarrClient extends ServarrBaseClient {
         throw new Error(`Invalid TMDB ID "${value}". Must be a positive integer`);
       }
 
-      return RadarrApi.getApiV3MovieLookupTmdb({ query: { tmdbId } });
+      return this.api.getApiV3MovieLookupTmdb({ query: { tmdbId } });
     }
 
     // Validate IMDB ID format (must be tt followed by digits)
@@ -222,7 +226,7 @@ export class RadarrClient extends ServarrBaseClient {
       );
     }
 
-    return RadarrApi.getApiV3MovieLookupImdb({ query: { imdbId: value } });
+    return this.api.getApiV3MovieLookupImdb({ query: { imdbId: value } });
   }
 
   // Root folder APIs
@@ -231,26 +235,26 @@ export class RadarrClient extends ServarrBaseClient {
    * Get all configured root folders
    */
   async getRootFolders() {
-    return RadarrApi.getApiV3Rootfolder();
+    return this.api.getApiV3Rootfolder();
   }
 
   async addRootFolder(path: string) {
-    return RadarrApi.postApiV3Rootfolder({
+    return this.api.postApiV3Rootfolder({
       body: { path },
     });
   }
 
   async deleteRootFolder(id: number) {
-    return RadarrApi.deleteApiV3RootfolderById({ path: { id } });
+    return this.api.deleteApiV3RootfolderById({ path: { id } });
   }
 
   // Filesystem APIs
   async getFilesystem(path?: string) {
-    return RadarrApi.getApiV3Filesystem(path ? { query: { path } } : {});
+    return this.api.getApiV3Filesystem(path ? { query: { path } } : {});
   }
 
   async getMediaFiles(path: string) {
-    return RadarrApi.getApiV3FilesystemMediafiles({ query: { path } });
+    return this.api.getApiV3FilesystemMediafiles({ query: { path } });
   }
 
   // Import APIs
@@ -259,7 +263,7 @@ export class RadarrClient extends ServarrBaseClient {
    * Import physical movie files into the library
    */
   async importMovies(movies: any[]) {
-    return RadarrApi.postApiV3MovieImport({ body: movies });
+    return this.api.postApiV3MovieImport({ body: movies });
   }
 
   // Manual Import APIs
@@ -287,7 +291,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (options.filterExistingFiles !== undefined)
       query.filterExistingFiles = options.filterExistingFiles;
 
-    return RadarrApi.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -295,7 +299,7 @@ export class RadarrClient extends ServarrBaseClient {
    * Does NOT perform the actual import — use {@link applyManualImport} for that.
    */
   async reprocessManualImport(files: ManualImportReprocessResource[]) {
-    return RadarrApi.postApiV3Manualimport({ body: files });
+    return this.api.postApiV3Manualimport({ body: files });
   }
 
   /**
@@ -318,49 +322,49 @@ export class RadarrClient extends ServarrBaseClient {
     if (movieId !== undefined) query.movieId = movieId;
     if (movieFileIds !== undefined) query.movieFileIds = movieFileIds;
 
-    return RadarrApi.getApiV3Moviefile(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Moviefile(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get a specific movie file by ID
    */
   async getMovieFile(id: number) {
-    return RadarrApi.getApiV3MoviefileById({ path: { id } });
+    return this.api.getApiV3MoviefileById({ path: { id } });
   }
 
   /**
    * Update a movie file
    */
   async updateMovieFile(id: string, movieFile: MovieFileResource) {
-    return RadarrApi.putApiV3MoviefileById({ path: { id }, body: movieFile });
+    return this.api.putApiV3MoviefileById({ path: { id }, body: movieFile });
   }
 
   /**
    * Delete a movie file from disk
    */
   async deleteMovieFile(id: number) {
-    return RadarrApi.deleteApiV3MoviefileById({ path: { id } });
+    return this.api.deleteApiV3MoviefileById({ path: { id } });
   }
 
   /**
    * Bulk update movie files using the editor endpoint
    */
   async updateMovieFilesEditor(movieFileList: MovieFileListResource) {
-    return RadarrApi.putApiV3MoviefileEditor({ body: movieFileList });
+    return this.api.putApiV3MoviefileEditor({ body: movieFileList });
   }
 
   /**
    * Bulk delete movie files
    */
   async deleteMovieFilesBulk(movieFileList: MovieFileListResource) {
-    return RadarrApi.deleteApiV3MoviefileBulk({ body: movieFileList });
+    return this.api.deleteApiV3MoviefileBulk({ body: movieFileList });
   }
 
   /**
    * Bulk update movie files
    */
   async updateMovieFilesBulk(movieFiles: MovieFileResource[]) {
-    return RadarrApi.putApiV3MoviefileBulk({ body: movieFiles });
+    return this.api.putApiV3MoviefileBulk({ body: movieFiles });
   }
 
   // Quality Profile APIs
@@ -369,42 +373,42 @@ export class RadarrClient extends ServarrBaseClient {
    * Get all quality profiles
    */
   async getQualityProfiles() {
-    return RadarrApi.getApiV3Qualityprofile();
+    return this.api.getApiV3Qualityprofile();
   }
 
   /**
    * Get a specific quality profile by ID
    */
   async getQualityProfile(id: number) {
-    return RadarrApi.getApiV3QualityprofileById({ path: { id } });
+    return this.api.getApiV3QualityprofileById({ path: { id } });
   }
 
   /**
    * Create a new quality profile
    */
   async addQualityProfile(profile: QualityProfileResource) {
-    return RadarrApi.postApiV3Qualityprofile({ body: profile });
+    return this.api.postApiV3Qualityprofile({ body: profile });
   }
 
   /**
    * Update an existing quality profile
    */
   async updateQualityProfile(id: number, profile: QualityProfileResource) {
-    return RadarrApi.putApiV3QualityprofileById({ path: { id: String(id) }, body: profile });
+    return this.api.putApiV3QualityprofileById({ path: { id: String(id) }, body: profile });
   }
 
   /**
    * Delete a quality profile
    */
   async deleteQualityProfile(id: number) {
-    return RadarrApi.deleteApiV3QualityprofileById({ path: { id } });
+    return this.api.deleteApiV3QualityprofileById({ path: { id } });
   }
 
   /**
    * Get quality profile schema for creating new profiles
    */
   async getQualityProfileSchema() {
-    return RadarrApi.getApiV3QualityprofileSchema();
+    return this.api.getApiV3QualityprofileSchema();
   }
 
   // Custom Format APIs
@@ -413,56 +417,56 @@ export class RadarrClient extends ServarrBaseClient {
    * Get all custom formats
    */
   async getCustomFormats() {
-    return RadarrApi.getApiV3Customformat();
+    return this.api.getApiV3Customformat();
   }
 
   /**
    * Get a specific custom format by ID
    */
   async getCustomFormat(id: number) {
-    return RadarrApi.getApiV3CustomformatById({ path: { id } });
+    return this.api.getApiV3CustomformatById({ path: { id } });
   }
 
   /**
    * Create a new custom format
    */
   async addCustomFormat(format: CustomFormatResource) {
-    return RadarrApi.postApiV3Customformat({ body: format });
+    return this.api.postApiV3Customformat({ body: format });
   }
 
   /**
    * Update an existing custom format
    */
   async updateCustomFormat(id: number, format: CustomFormatResource) {
-    return RadarrApi.putApiV3CustomformatById({ path: { id: String(id) }, body: format });
+    return this.api.putApiV3CustomformatById({ path: { id: String(id) }, body: format });
   }
 
   /**
    * Delete a custom format
    */
   async deleteCustomFormat(id: number) {
-    return RadarrApi.deleteApiV3CustomformatById({ path: { id } });
+    return this.api.deleteApiV3CustomformatById({ path: { id } });
   }
 
   /**
    * Bulk update custom formats
    */
   async updateCustomFormatsBulk(formats: CustomFormatBulkResource) {
-    return RadarrApi.putApiV3CustomformatBulk({ body: formats });
+    return this.api.putApiV3CustomformatBulk({ body: formats });
   }
 
   /**
    * Bulk delete custom formats
    */
   async deleteCustomFormatsBulk(ids: number[]) {
-    return RadarrApi.deleteApiV3CustomformatBulk({ body: { ids } });
+    return this.api.deleteApiV3CustomformatBulk({ body: { ids } });
   }
 
   /**
    * Get custom format schema for creating new formats
    */
   async getCustomFormatSchema() {
-    return RadarrApi.getApiV3CustomformatSchema();
+    return this.api.getApiV3CustomformatSchema();
   }
 
   // Download Client APIs (Radarr-specific bulk operations)
@@ -471,14 +475,14 @@ export class RadarrClient extends ServarrBaseClient {
    * Bulk update download clients
    */
   async updateDownloadClientsBulk(clients: DownloadClientBulkResource) {
-    return RadarrApi.putApiV3DownloadclientBulk({ body: clients });
+    return this.api.putApiV3DownloadclientBulk({ body: clients });
   }
 
   /**
    * Bulk delete download clients
    */
   async deleteDownloadClientsBulk(ids: number[]) {
-    return RadarrApi.deleteApiV3DownloadclientBulk({ body: { ids } });
+    return this.api.deleteApiV3DownloadclientBulk({ body: { ids } });
   }
 
   // Calendar APIs
@@ -492,7 +496,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (endDate) query.end = endDate;
     if (unmonitored !== undefined) query.unmonitored = unmonitored;
 
-    return RadarrApi.getApiV3Calendar(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Calendar(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -504,7 +508,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (futureDays !== undefined) query.futureDays = futureDays;
     if (tags) query.tags = tags;
 
-    return RadarrApi.getFeedV3CalendarRadarrIcs(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getFeedV3CalendarRadarrIcs(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Queue APIs
@@ -527,7 +531,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (includeUnknownMovieItems !== undefined)
       query.includeUnknownMovieItems = includeUnknownMovieItems;
 
-    return RadarrApi.getApiV3Queue(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Queue(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -538,7 +542,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return RadarrApi.deleteApiV3QueueById({
+    return this.api.deleteApiV3QueueById({
       path: { id },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -552,21 +556,21 @@ export class RadarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) body.removeFromClient = removeFromClient;
     if (blocklist !== undefined) body.blocklist = blocklist;
 
-    return RadarrApi.deleteApiV3QueueBulk({ body });
+    return this.api.deleteApiV3QueueBulk({ body });
   }
 
   /**
    * Force grab/download a queue item
    */
   async grabQueueItem(id: number) {
-    return RadarrApi.postApiV3QueueGrabById({ path: { id } });
+    return this.api.postApiV3QueueGrabById({ path: { id } });
   }
 
   /**
    * Force grab/download multiple queue items
    */
   async grabQueueItemsBulk(ids: number[]) {
-    return RadarrApi.postApiV3QueueGrabBulk({ body: { ids } });
+    return this.api.postApiV3QueueGrabBulk({ body: { ids } });
   }
 
   /**
@@ -577,14 +581,14 @@ export class RadarrClient extends ServarrBaseClient {
     if (movieId !== undefined) query.movieId = movieId;
     if (includeMovie !== undefined) query.includeMovie = includeMovie;
 
-    return RadarrApi.getApiV3QueueDetails(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3QueueDetails(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get queue status summary
    */
   async getQueueStatus() {
-    return RadarrApi.getApiV3QueueStatus();
+    return this.api.getApiV3QueueStatus();
   }
 
   // Import List APIs
@@ -593,56 +597,56 @@ export class RadarrClient extends ServarrBaseClient {
    * Get all import lists
    */
   async getImportLists() {
-    return RadarrApi.getApiV3Importlist();
+    return this.api.getApiV3Importlist();
   }
 
   /**
    * Get a specific import list by ID
    */
   async getImportList(id: number) {
-    return RadarrApi.getApiV3ImportlistById({ path: { id } });
+    return this.api.getApiV3ImportlistById({ path: { id } });
   }
 
   /**
    * Add a new import list
    */
   async addImportList(importList: ImportListResource) {
-    return RadarrApi.postApiV3Importlist({ body: importList });
+    return this.api.postApiV3Importlist({ body: importList });
   }
 
   /**
    * Update an existing import list
    */
   async updateImportList(id: number, importList: ImportListResource) {
-    return RadarrApi.putApiV3ImportlistById({ path: { id }, body: importList });
+    return this.api.putApiV3ImportlistById({ path: { id }, body: importList });
   }
 
   /**
    * Delete an import list
    */
   async deleteImportList(id: number) {
-    return RadarrApi.deleteApiV3ImportlistById({ path: { id } });
+    return this.api.deleteApiV3ImportlistById({ path: { id } });
   }
 
   /**
    * Get import list schema for available list types
    */
   async getImportListSchema() {
-    return RadarrApi.getApiV3ImportlistSchema();
+    return this.api.getApiV3ImportlistSchema();
   }
 
   /**
    * Test an import list configuration
    */
   async testImportList(importList: ImportListResource) {
-    return RadarrApi.postApiV3ImportlistTest({ body: importList });
+    return this.api.postApiV3ImportlistTest({ body: importList });
   }
 
   /**
    * Test all import lists
    */
   async testAllImportLists() {
-    return RadarrApi.postApiV3ImportlistTestall();
+    return this.api.postApiV3ImportlistTestall();
   }
 
   // History APIs
@@ -666,7 +670,7 @@ export class RadarrClient extends ServarrBaseClient {
     if (movieId !== undefined) query.movieId = movieId;
     if (downloadId) query.downloadId = downloadId;
 
-    return RadarrApi.getApiV3History(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3History(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -676,7 +680,7 @@ export class RadarrClient extends ServarrBaseClient {
     const query: any = { date };
     if (movieId !== undefined) query.movieId = movieId;
 
-    return RadarrApi.getApiV3HistorySince({ query });
+    return this.api.getApiV3HistorySince({ query });
   }
 
   /**
@@ -686,14 +690,14 @@ export class RadarrClient extends ServarrBaseClient {
     const query: any = { movieId };
     if (eventType !== undefined) query.eventType = eventType;
 
-    return RadarrApi.getApiV3HistoryMovie({ query });
+    return this.api.getApiV3HistoryMovie({ query });
   }
 
   /**
    * Mark a failed download as failed in history
    */
   async markHistoryItemFailed(id: number) {
-    return RadarrApi.postApiV3HistoryFailedById({ path: { id } });
+    return this.api.postApiV3HistoryFailedById({ path: { id } });
   }
 
   // Blocklist APIs
@@ -708,21 +712,21 @@ export class RadarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return RadarrApi.getApiV3Blocklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Blocklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Remove a release from the blocklist
    */
   async removeBlocklistItem(id: number) {
-    return RadarrApi.deleteApiV3BlocklistById({ path: { id } });
+    return this.api.deleteApiV3BlocklistById({ path: { id } });
   }
 
   /**
    * Bulk remove releases from the blocklist
    */
   async removeBlocklistItemsBulk(ids: number[]) {
-    return RadarrApi.deleteApiV3BlocklistBulk({ body: { ids } });
+    return this.api.deleteApiV3BlocklistBulk({ body: { ids } });
   }
 
   // Wanted APIs
@@ -731,14 +735,14 @@ export class RadarrClient extends ServarrBaseClient {
     const query: Record<string, any> = {};
     if (page !== undefined) query.page = page;
     if (pageSize !== undefined) query.pageSize = pageSize;
-    return RadarrApi.getApiV3WantedMissing(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3WantedMissing(Object.keys(query).length > 0 ? { query } : {});
   }
 
   async getWantedCutoff(page?: number, pageSize?: number) {
     const query: Record<string, any> = {};
     if (page !== undefined) query.page = page;
     if (pageSize !== undefined) query.pageSize = pageSize;
-    return RadarrApi.getApiV3WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Configuration Management APIs
@@ -747,77 +751,77 @@ export class RadarrClient extends ServarrBaseClient {
    * Get naming configuration settings
    */
   async getNamingConfig() {
-    return RadarrApi.getApiV3ConfigNaming();
+    return this.api.getApiV3ConfigNaming();
   }
 
   /**
    * Get naming configuration by ID
    */
   async getNamingConfigById(id: number) {
-    return RadarrApi.getApiV3ConfigNamingById({ path: { id } });
+    return this.api.getApiV3ConfigNamingById({ path: { id } });
   }
 
   /**
    * Update naming configuration
    */
   async updateNamingConfig(id: number, config: NamingConfigResource) {
-    return RadarrApi.putApiV3ConfigNamingById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV3ConfigNamingById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get naming configuration examples
    */
   async getNamingConfigExamples() {
-    return RadarrApi.getApiV3ConfigNamingExamples();
+    return this.api.getApiV3ConfigNamingExamples();
   }
 
   /**
    * Get media management configuration settings
    */
   async getMediaManagementConfig() {
-    return RadarrApi.getApiV3ConfigMediamanagement();
+    return this.api.getApiV3ConfigMediamanagement();
   }
 
   /**
    * Get media management configuration by ID
    */
   async getMediaManagementConfigById(id: number) {
-    return RadarrApi.getApiV3ConfigMediamanagementById({ path: { id } });
+    return this.api.getApiV3ConfigMediamanagementById({ path: { id } });
   }
 
   /**
    * Update media management configuration
    */
   async updateMediaManagementConfig(id: number, config: MediaManagementConfigResource) {
-    return RadarrApi.putApiV3ConfigMediamanagementById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV3ConfigMediamanagementById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get system logs
    */
   async getSystemLogs() {
-    return RadarrApi.getApiV3Log();
+    return this.api.getApiV3Log();
   }
 
   /**
    * Get disk space information
    */
   async getDiskSpace() {
-    return RadarrApi.getApiV3Diskspace();
+    return this.api.getApiV3Diskspace();
   }
 
   /**
    * Search for releases, optionally scoped to a movie
    */
   async getRelease(movieId?: number) {
-    return RadarrApi.getApiV3Release(movieId === undefined ? {} : { query: { movieId } });
+    return this.api.getApiV3Release(movieId === undefined ? {} : { query: { movieId } });
   }
 
   /**
    * Grab/push a release
    */
   async addRelease(release: RadarrApi.ReleaseResource) {
-    return RadarrApi.postApiV3Release({ body: release });
+    return this.api.postApiV3Release({ body: release });
   }
 }
 

--- a/src/clients/readarr.ts
+++ b/src/clients/readarr.ts
@@ -1,6 +1,7 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import { bindApiClient } from '../core/bind-api';
 import type { ServarrClientConfig } from '../core/types';
-import { client as readarrClient } from '../generated/readarr/client.gen';
+import { createClient, createConfig } from '../generated/readarr/client';
 import * as ReadarrApi from '../generated/readarr/index';
 import type {
   AuthorResourceWritable,
@@ -30,77 +31,80 @@ import type {
  * ```
  */
 export class ReadarrClient extends ServarrBaseClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly api = bindApiClient(ReadarrApi, this.rawClient);
+
   protected readonly ops: ServarrOps = {
     // System
-    getSystemStatus: ReadarrApi.getApiV1SystemStatus,
-    getHealth: ReadarrApi.getApiV1Health,
+    getSystemStatus: this.api.getApiV1SystemStatus,
+    getHealth: this.api.getApiV1Health,
 
     // Tags
-    getTags: ReadarrApi.getApiV1Tag,
-    createTag: ReadarrApi.postApiV1Tag,
-    getTagById: ReadarrApi.getApiV1TagById,
-    updateTagById: ReadarrApi.putApiV1TagById,
-    deleteTagById: ReadarrApi.deleteApiV1TagById,
-    getTagDetails: ReadarrApi.getApiV1TagDetail,
-    getTagDetailById: ReadarrApi.getApiV1TagDetailById,
+    getTags: this.api.getApiV1Tag,
+    createTag: this.api.postApiV1Tag,
+    getTagById: this.api.getApiV1TagById,
+    updateTagById: this.api.putApiV1TagById,
+    deleteTagById: this.api.deleteApiV1TagById,
+    getTagDetails: this.api.getApiV1TagDetail,
+    getTagDetailById: this.api.getApiV1TagDetailById,
 
     // Notifications
-    getNotifications: ReadarrApi.getApiV1Notification,
-    createNotification: ReadarrApi.postApiV1Notification,
-    getNotificationById: ReadarrApi.getApiV1NotificationById,
-    updateNotificationById: ReadarrApi.putApiV1NotificationById,
-    deleteNotificationById: ReadarrApi.deleteApiV1NotificationById,
-    getNotificationSchema: ReadarrApi.getApiV1NotificationSchema,
-    testNotification: ReadarrApi.postApiV1NotificationTest,
-    testAllNotifications: ReadarrApi.postApiV1NotificationTestall,
+    getNotifications: this.api.getApiV1Notification,
+    createNotification: this.api.postApiV1Notification,
+    getNotificationById: this.api.getApiV1NotificationById,
+    updateNotificationById: this.api.putApiV1NotificationById,
+    deleteNotificationById: this.api.deleteApiV1NotificationById,
+    getNotificationSchema: this.api.getApiV1NotificationSchema,
+    testNotification: this.api.postApiV1NotificationTest,
+    testAllNotifications: this.api.postApiV1NotificationTestall,
 
     // Download Clients
-    getDownloadClients: ReadarrApi.getApiV1Downloadclient,
-    createDownloadClient: ReadarrApi.postApiV1Downloadclient,
-    getDownloadClientById: ReadarrApi.getApiV1DownloadclientById,
-    updateDownloadClientById: ReadarrApi.putApiV1DownloadclientById,
-    deleteDownloadClientById: ReadarrApi.deleteApiV1DownloadclientById,
-    getDownloadClientSchema: ReadarrApi.getApiV1DownloadclientSchema,
-    testDownloadClient: ReadarrApi.postApiV1DownloadclientTest,
-    testAllDownloadClients: ReadarrApi.postApiV1DownloadclientTestall,
+    getDownloadClients: this.api.getApiV1Downloadclient,
+    createDownloadClient: this.api.postApiV1Downloadclient,
+    getDownloadClientById: this.api.getApiV1DownloadclientById,
+    updateDownloadClientById: this.api.putApiV1DownloadclientById,
+    deleteDownloadClientById: this.api.deleteApiV1DownloadclientById,
+    getDownloadClientSchema: this.api.getApiV1DownloadclientSchema,
+    testDownloadClient: this.api.postApiV1DownloadclientTest,
+    testAllDownloadClients: this.api.postApiV1DownloadclientTestall,
 
     // Indexers
-    getIndexers: ReadarrApi.getApiV1Indexer,
-    createIndexer: ReadarrApi.postApiV1Indexer,
-    getIndexerById: ReadarrApi.getApiV1IndexerById,
-    updateIndexerById: ReadarrApi.putApiV1IndexerById,
-    deleteIndexerById: ReadarrApi.deleteApiV1IndexerById,
-    getIndexerSchema: ReadarrApi.getApiV1IndexerSchema,
-    testIndexer: ReadarrApi.postApiV1IndexerTest,
-    testAllIndexers: ReadarrApi.postApiV1IndexerTestall,
+    getIndexers: this.api.getApiV1Indexer,
+    createIndexer: this.api.postApiV1Indexer,
+    getIndexerById: this.api.getApiV1IndexerById,
+    updateIndexerById: this.api.putApiV1IndexerById,
+    deleteIndexerById: this.api.deleteApiV1IndexerById,
+    getIndexerSchema: this.api.getApiV1IndexerSchema,
+    testIndexer: this.api.postApiV1IndexerTest,
+    testAllIndexers: this.api.postApiV1IndexerTestall,
 
     // System Admin
-    restartSystem: ReadarrApi.postApiV1SystemRestart,
-    shutdownSystem: ReadarrApi.postApiV1SystemShutdown,
-    getBackups: ReadarrApi.getApiV1SystemBackup,
-    deleteBackup: ReadarrApi.deleteApiV1SystemBackupById,
-    restoreBackup: ReadarrApi.postApiV1SystemBackupRestoreById,
-    uploadBackup: ReadarrApi.postApiV1SystemBackupRestoreUpload,
-    getLogFiles: ReadarrApi.getApiV1LogFile,
-    getLogFileByName: ReadarrApi.getApiV1LogFileByFilename,
+    restartSystem: this.api.postApiV1SystemRestart,
+    shutdownSystem: this.api.postApiV1SystemShutdown,
+    getBackups: this.api.getApiV1SystemBackup,
+    deleteBackup: this.api.deleteApiV1SystemBackupById,
+    restoreBackup: this.api.postApiV1SystemBackupRestoreById,
+    uploadBackup: this.api.postApiV1SystemBackupRestoreUpload,
+    getLogFiles: this.api.getApiV1LogFile,
+    getLogFileByName: this.api.getApiV1LogFileByFilename,
 
     // Commands
-    runCommand: ReadarrApi.postApiV1Command,
-    getCommands: ReadarrApi.getApiV1Command,
+    runCommand: this.api.postApiV1Command,
+    getCommands: this.api.getApiV1Command,
 
     // Host Config
-    getHostConfig: ReadarrApi.getApiV1ConfigHost,
-    getHostConfigById: ReadarrApi.getApiV1ConfigHostById,
-    updateHostConfig: ReadarrApi.putApiV1ConfigHostById,
+    getHostConfig: this.api.getApiV1ConfigHost,
+    getHostConfigById: this.api.getApiV1ConfigHostById,
+    updateHostConfig: this.api.putApiV1ConfigHostById,
 
     // UI Config
-    getUiConfig: ReadarrApi.getApiV1ConfigUi,
-    getUiConfigById: ReadarrApi.getApiV1ConfigUiById,
-    updateUiConfig: ReadarrApi.putApiV1ConfigUiById,
+    getUiConfig: this.api.getApiV1ConfigUi,
+    getUiConfigById: this.api.getApiV1ConfigUiById,
+    updateUiConfig: this.api.putApiV1ConfigUiById,
   };
 
   constructor(config: ServarrClientConfig) {
-    super(config, readarrClient);
+    super(config, createClient(createConfig({ baseUrl: 'http://localhost' })));
   }
 
   // Author APIs
@@ -109,32 +113,32 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get all authors in the library
    */
   async getAuthors() {
-    return ReadarrApi.getApiV1Author();
+    return this.api.getApiV1Author();
   }
 
   async getAuthor(id: number) {
-    return ReadarrApi.getApiV1AuthorById({ path: { id } });
+    return this.api.getApiV1AuthorById({ path: { id } });
   }
 
   async addAuthor(author: AuthorResourceWritable) {
-    return ReadarrApi.postApiV1Author({ body: author });
+    return this.api.postApiV1Author({ body: author });
   }
 
   async updateAuthor(id: number, author: AuthorResourceWritable) {
-    return ReadarrApi.putApiV1AuthorById({ path: { id: String(id) }, body: author });
+    return this.api.putApiV1AuthorById({ path: { id: String(id) }, body: author });
   }
 
   async deleteAuthor(id: number) {
-    return ReadarrApi.deleteApiV1AuthorById({ path: { id } });
+    return this.api.deleteApiV1AuthorById({ path: { id } });
   }
 
   // Book APIs
   async getBooks() {
-    return ReadarrApi.getApiV1Book();
+    return this.api.getApiV1Book();
   }
 
   async getBook(id: number) {
-    return ReadarrApi.getApiV1BookById({ path: { id } });
+    return this.api.getApiV1BookById({ path: { id } });
   }
 
   // Search APIs
@@ -143,22 +147,22 @@ export class ReadarrClient extends ServarrBaseClient {
    * Search for authors using Goodreads database
    */
   async searchAuthors(term: string) {
-    return ReadarrApi.getApiV1AuthorLookup({ query: { term } });
+    return this.api.getApiV1AuthorLookup({ query: { term } });
   }
 
   // Root folder APIs
   async getRootFolders() {
-    return ReadarrApi.getApiV1Rootfolder();
+    return this.api.getApiV1Rootfolder();
   }
 
   async addRootFolder(path: string) {
-    return ReadarrApi.postApiV1Rootfolder({
+    return this.api.postApiV1Rootfolder({
       body: { path },
     });
   }
 
   async deleteRootFolder(id: number) {
-    return ReadarrApi.deleteApiV1RootfolderById({ path: { id } });
+    return this.api.deleteApiV1RootfolderById({ path: { id } });
   }
 
   // Configuration Management APIs
@@ -167,91 +171,91 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get naming configuration settings
    */
   async getNamingConfig() {
-    return ReadarrApi.getApiV1ConfigNaming();
+    return this.api.getApiV1ConfigNaming();
   }
 
   /**
    * Get naming configuration by ID
    */
   async getNamingConfigById(id: number) {
-    return ReadarrApi.getApiV1ConfigNamingById({ path: { id } });
+    return this.api.getApiV1ConfigNamingById({ path: { id } });
   }
 
   /**
    * Update naming configuration
    */
   async updateNamingConfig(id: number, config: NamingConfigResource) {
-    return ReadarrApi.putApiV1ConfigNamingById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigNamingById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get naming configuration examples
    */
   async getNamingConfigExamples() {
-    return ReadarrApi.getApiV1ConfigNamingExamples();
+    return this.api.getApiV1ConfigNamingExamples();
   }
 
   /**
    * Get media management configuration settings
    */
   async getMediaManagementConfig() {
-    return ReadarrApi.getApiV1ConfigMediamanagement();
+    return this.api.getApiV1ConfigMediamanagement();
   }
 
   /**
    * Get media management configuration by ID
    */
   async getMediaManagementConfigById(id: number) {
-    return ReadarrApi.getApiV1ConfigMediamanagementById({ path: { id } });
+    return this.api.getApiV1ConfigMediamanagementById({ path: { id } });
   }
 
   /**
    * Update media management configuration
    */
   async updateMediaManagementConfig(id: number, config: MediaManagementConfigResource) {
-    return ReadarrApi.putApiV1ConfigMediamanagementById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigMediamanagementById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get development configuration settings
    */
   async getDevelopmentConfig() {
-    return ReadarrApi.getApiV1ConfigDevelopment();
+    return this.api.getApiV1ConfigDevelopment();
   }
 
   /**
    * Get development configuration by ID
    */
   async getDevelopmentConfigById(id: number) {
-    return ReadarrApi.getApiV1ConfigDevelopmentById({ path: { id } });
+    return this.api.getApiV1ConfigDevelopmentById({ path: { id } });
   }
 
   /**
    * Update development configuration
    */
   async updateDevelopmentConfig(id: number, config: DevelopmentConfigResource) {
-    return ReadarrApi.putApiV1ConfigDevelopmentById({ path: { id: String(id) }, body: config });
+    return this.api.putApiV1ConfigDevelopmentById({ path: { id: String(id) }, body: config });
   }
 
   /**
    * Get metadata provider configuration settings
    */
   async getMetadataProviderConfig() {
-    return ReadarrApi.getApiV1ConfigMetadataprovider();
+    return this.api.getApiV1ConfigMetadataprovider();
   }
 
   /**
    * Get metadata provider configuration by ID
    */
   async getMetadataProviderConfigById(id: number) {
-    return ReadarrApi.getApiV1ConfigMetadataproviderById({ path: { id } });
+    return this.api.getApiV1ConfigMetadataproviderById({ path: { id } });
   }
 
   /**
    * Update metadata provider configuration
    */
   async updateMetadataProviderConfig(id: number, config: MetadataProviderConfigResource) {
-    return ReadarrApi.putApiV1ConfigMetadataproviderById({
+    return this.api.putApiV1ConfigMetadataproviderById({
       path: { id: String(id) },
       body: config,
     });
@@ -261,14 +265,14 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get system logs
    */
   async getSystemLogs() {
-    return ReadarrApi.getApiV1Log();
+    return this.api.getApiV1Log();
   }
 
   /**
    * Get disk space information
    */
   async getDiskSpace() {
-    return ReadarrApi.getApiV1Diskspace();
+    return this.api.getApiV1Diskspace();
   }
 
   // Book Management APIs (Enhanced)
@@ -277,28 +281,28 @@ export class ReadarrClient extends ServarrBaseClient {
    * Add a new book
    */
   async addBook(book: BookResource) {
-    return ReadarrApi.postApiV1Book({ body: book as never });
+    return this.api.postApiV1Book({ body: book as never });
   }
 
   /**
    * Update an existing book
    */
   async updateBook(id: number, book: BookResource) {
-    return ReadarrApi.putApiV1BookById({ path: { id: String(id) }, body: book as never });
+    return this.api.putApiV1BookById({ path: { id: String(id) }, body: book as never });
   }
 
   /**
    * Delete a book
    */
   async deleteBook(id: number) {
-    return ReadarrApi.deleteApiV1BookById({ path: { id } });
+    return this.api.deleteApiV1BookById({ path: { id } });
   }
 
   /**
    * Search for books
    */
   async searchBooks(term: string) {
-    return ReadarrApi.getApiV1BookLookup({ query: { term } });
+    return this.api.getApiV1BookLookup({ query: { term } });
   }
 
   // Calendar APIs
@@ -308,7 +312,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (end) query.end = end;
     if (unmonitored !== undefined) query.unmonitored = unmonitored;
 
-    return ReadarrApi.getApiV1Calendar(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Calendar(Object.keys(query).length > 0 ? { query } : {});
   }
 
   async getCalendarFeed(pastDays?: number, futureDays?: number, tagList?: string) {
@@ -317,7 +321,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (futureDays !== undefined) query.futureDays = futureDays;
     if (tagList) query.tagList = tagList;
 
-    return ReadarrApi.getFeedV1CalendarReadarrIcs(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getFeedV1CalendarReadarrIcs(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Book File APIs
@@ -337,42 +341,42 @@ export class ReadarrClient extends ServarrBaseClient {
     if (bookId !== undefined) query.bookId = bookId;
     if (unmapped !== undefined) query.unmapped = unmapped;
 
-    return ReadarrApi.getApiV1Bookfile(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Bookfile(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get a specific book file by ID
    */
   async getBookFile(id: number) {
-    return ReadarrApi.getApiV1BookfileById({ path: { id } });
+    return this.api.getApiV1BookfileById({ path: { id } });
   }
 
   /**
    * Update a book file
    */
   async updateBookFile(id: string, bookFile: BookFileResourceWritable) {
-    return ReadarrApi.putApiV1BookfileById({ path: { id }, body: bookFile });
+    return this.api.putApiV1BookfileById({ path: { id }, body: bookFile });
   }
 
   /**
    * Delete a book file from disk
    */
   async deleteBookFile(id: number) {
-    return ReadarrApi.deleteApiV1BookfileById({ path: { id } });
+    return this.api.deleteApiV1BookfileById({ path: { id } });
   }
 
   /**
    * Bulk update book files using the editor endpoint
    */
   async updateBookFilesEditor(bookFileList: BookFileListResource) {
-    return ReadarrApi.putApiV1BookfileEditor({ body: bookFileList });
+    return this.api.putApiV1BookfileEditor({ body: bookFileList });
   }
 
   /**
    * Bulk delete book files
    */
   async deleteBookFilesBulk(bookFileList: BookFileListResource) {
-    return ReadarrApi.deleteApiV1BookfileBulk({ body: bookFileList });
+    return this.api.deleteApiV1BookfileBulk({ body: bookFileList });
   }
 
   // Quality Profile APIs
@@ -381,42 +385,42 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get all quality profiles
    */
   async getQualityProfiles() {
-    return ReadarrApi.getApiV1Qualityprofile();
+    return this.api.getApiV1Qualityprofile();
   }
 
   /**
    * Get a specific quality profile by ID
    */
   async getQualityProfile(id: number) {
-    return ReadarrApi.getApiV1QualityprofileById({ path: { id } });
+    return this.api.getApiV1QualityprofileById({ path: { id } });
   }
 
   /**
    * Create a new quality profile
    */
   async addQualityProfile(profile: QualityProfileResource) {
-    return ReadarrApi.postApiV1Qualityprofile({ body: profile });
+    return this.api.postApiV1Qualityprofile({ body: profile });
   }
 
   /**
    * Update an existing quality profile
    */
   async updateQualityProfile(id: number, profile: QualityProfileResource) {
-    return ReadarrApi.putApiV1QualityprofileById({ path: { id: String(id) }, body: profile });
+    return this.api.putApiV1QualityprofileById({ path: { id: String(id) }, body: profile });
   }
 
   /**
    * Delete a quality profile
    */
   async deleteQualityProfile(id: number) {
-    return ReadarrApi.deleteApiV1QualityprofileById({ path: { id } });
+    return this.api.deleteApiV1QualityprofileById({ path: { id } });
   }
 
   /**
    * Get quality profile schema
    */
   async getQualityProfileSchema() {
-    return ReadarrApi.getApiV1QualityprofileSchema();
+    return this.api.getApiV1QualityprofileSchema();
   }
 
   // Custom Format APIs
@@ -425,42 +429,42 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get all custom formats
    */
   async getCustomFormats() {
-    return ReadarrApi.getApiV1Customformat();
+    return this.api.getApiV1Customformat();
   }
 
   /**
    * Get a specific custom format by ID
    */
   async getCustomFormat(id: number) {
-    return ReadarrApi.getApiV1CustomformatById({ path: { id } });
+    return this.api.getApiV1CustomformatById({ path: { id } });
   }
 
   /**
    * Create a new custom format
    */
   async addCustomFormat(format: CustomFormatResource) {
-    return ReadarrApi.postApiV1Customformat({ body: format });
+    return this.api.postApiV1Customformat({ body: format });
   }
 
   /**
    * Update an existing custom format
    */
   async updateCustomFormat(id: number, format: CustomFormatResource) {
-    return ReadarrApi.putApiV1CustomformatById({ path: { id: String(id) }, body: format });
+    return this.api.putApiV1CustomformatById({ path: { id: String(id) }, body: format });
   }
 
   /**
    * Delete a custom format
    */
   async deleteCustomFormat(id: number) {
-    return ReadarrApi.deleteApiV1CustomformatById({ path: { id } });
+    return this.api.deleteApiV1CustomformatById({ path: { id } });
   }
 
   /**
    * Get custom format schema
    */
   async getCustomFormatSchema() {
-    return ReadarrApi.getApiV1CustomformatSchema();
+    return this.api.getApiV1CustomformatSchema();
   }
 
   // Import List APIs
@@ -469,56 +473,56 @@ export class ReadarrClient extends ServarrBaseClient {
    * Get all import lists
    */
   async getImportLists() {
-    return ReadarrApi.getApiV1Importlist();
+    return this.api.getApiV1Importlist();
   }
 
   /**
    * Get a specific import list by ID
    */
   async getImportList(id: number) {
-    return ReadarrApi.getApiV1ImportlistById({ path: { id } });
+    return this.api.getApiV1ImportlistById({ path: { id } });
   }
 
   /**
    * Add a new import list
    */
   async addImportList(importList: ImportListResource) {
-    return ReadarrApi.postApiV1Importlist({ body: importList });
+    return this.api.postApiV1Importlist({ body: importList });
   }
 
   /**
    * Update an existing import list
    */
   async updateImportList(id: number, importList: ImportListResource) {
-    return ReadarrApi.putApiV1ImportlistById({ path: { id: String(id) }, body: importList });
+    return this.api.putApiV1ImportlistById({ path: { id: String(id) }, body: importList });
   }
 
   /**
    * Delete an import list
    */
   async deleteImportList(id: number) {
-    return ReadarrApi.deleteApiV1ImportlistById({ path: { id } });
+    return this.api.deleteApiV1ImportlistById({ path: { id } });
   }
 
   /**
    * Get import list schema for available list types
    */
   async getImportListSchema() {
-    return ReadarrApi.getApiV1ImportlistSchema();
+    return this.api.getApiV1ImportlistSchema();
   }
 
   /**
    * Test an import list configuration
    */
   async testImportList(importList: ImportListResource) {
-    return ReadarrApi.postApiV1ImportlistTest({ body: importList });
+    return this.api.postApiV1ImportlistTest({ body: importList });
   }
 
   /**
    * Test all import lists
    */
   async testAllImportLists() {
-    return ReadarrApi.postApiV1ImportlistTestall();
+    return this.api.postApiV1ImportlistTestall();
   }
 
   // History APIs
@@ -542,7 +546,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (authorId !== undefined) query.authorId = authorId;
     if (downloadId) query.downloadId = downloadId;
 
-    return ReadarrApi.getApiV1History(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1History(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -552,7 +556,7 @@ export class ReadarrClient extends ServarrBaseClient {
     const query: any = { date };
     if (authorId !== undefined) query.authorId = authorId;
 
-    return ReadarrApi.getApiV1HistorySince({ query });
+    return this.api.getApiV1HistorySince({ query });
   }
 
   /**
@@ -563,14 +567,14 @@ export class ReadarrClient extends ServarrBaseClient {
     if (bookId !== undefined) query.bookId = bookId;
     if (eventType !== undefined) query.eventType = eventType;
 
-    return ReadarrApi.getApiV1HistoryAuthor({ query });
+    return this.api.getApiV1HistoryAuthor({ query });
   }
 
   /**
    * Mark a failed download as failed in history
    */
   async markHistoryItemFailed(id: number) {
-    return ReadarrApi.postApiV1HistoryFailedById({ path: { id } });
+    return this.api.postApiV1HistoryFailedById({ path: { id } });
   }
 
   // Queue APIs
@@ -593,7 +597,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (includeUnknownAuthorItems !== undefined)
       query.includeUnknownAuthorItems = includeUnknownAuthorItems;
 
-    return ReadarrApi.getApiV1Queue(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Queue(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -604,7 +608,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return ReadarrApi.deleteApiV1QueueById({
+    return this.api.deleteApiV1QueueById({
       path: { id },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -618,7 +622,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return ReadarrApi.deleteApiV1QueueBulk({
+    return this.api.deleteApiV1QueueBulk({
       body: { ids },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -628,14 +632,14 @@ export class ReadarrClient extends ServarrBaseClient {
    * Force grab a queue item
    */
   async grabQueueItem(id: number) {
-    return ReadarrApi.postApiV1QueueGrabById({ path: { id } });
+    return this.api.postApiV1QueueGrabById({ path: { id } });
   }
 
   /**
    * Force grab multiple queue items
    */
   async grabQueueItemsBulk(ids: number[]) {
-    return ReadarrApi.postApiV1QueueGrabBulk({ body: { ids } });
+    return this.api.postApiV1QueueGrabBulk({ body: { ids } });
   }
 
   /**
@@ -647,14 +651,14 @@ export class ReadarrClient extends ServarrBaseClient {
     if (includeUnknownAuthorItems !== undefined)
       query.includeUnknownAuthorItems = includeUnknownAuthorItems;
 
-    return ReadarrApi.getApiV1QueueDetails(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1QueueDetails(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get queue status summary
    */
   async getQueueStatus() {
-    return ReadarrApi.getApiV1QueueStatus();
+    return this.api.getApiV1QueueStatus();
   }
 
   // Blocklist APIs
@@ -669,21 +673,21 @@ export class ReadarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return ReadarrApi.getApiV1Blocklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1Blocklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Remove a release from the blocklist
    */
   async removeBlocklistItem(id: number) {
-    return ReadarrApi.deleteApiV1BlocklistById({ path: { id } });
+    return this.api.deleteApiV1BlocklistById({ path: { id } });
   }
 
   /**
    * Bulk remove releases from the blocklist
    */
   async removeBlocklistItemsBulk(ids: number[]) {
-    return ReadarrApi.deleteApiV1BlocklistBulk({ body: { ids } });
+    return this.api.deleteApiV1BlocklistBulk({ body: { ids } });
   }
 
   /**
@@ -703,7 +707,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (sortDirection) query.sortDirection = sortDirection;
     if (monitored !== undefined) query.monitored = monitored;
 
-    return ReadarrApi.getApiV1WantedMissing(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1WantedMissing(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -723,7 +727,7 @@ export class ReadarrClient extends ServarrBaseClient {
     if (sortDirection) query.sortDirection = sortDirection;
     if (monitored !== undefined) query.monitored = monitored;
 
-    return ReadarrApi.getApiV1WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV1WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
   }
 }
 

--- a/src/clients/seerr.ts
+++ b/src/clients/seerr.ts
@@ -1,6 +1,7 @@
+import { bindApiClient } from '../core/bind-api';
 import { createServarrClient } from '../core/client';
 import type { ServarrClientConfig } from '../core/types';
-import { client as seerrClient } from '../generated/seerr/client.gen';
+import { createClient, createConfig } from '../generated/seerr/client';
 import * as SeerrApi from '../generated/seerr/index';
 import type {
   GetRequestData,
@@ -29,12 +30,15 @@ type RequestFilter = NonNullable<GetRequestData['query']>['filter'];
  * ```
  */
 export class SeerrClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly rawClient = createClient(createConfig({ baseUrl: 'http://localhost' }));
+  private readonly api = bindApiClient(SeerrApi, this.rawClient);
   private clientConfig: ReturnType<typeof createServarrClient>;
 
   constructor(config: ServarrClientConfig) {
     this.clientConfig = createServarrClient(config);
 
-    seerrClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: `${this.clientConfig.getBaseUrl()}/api/v1`,
       headers: {
         'X-Api-Key': this.clientConfig.config.apiKey,
@@ -47,7 +51,7 @@ export class SeerrClient {
   // Status APIs
 
   async getSystemStatus() {
-    return SeerrApi.getStatus();
+    return this.api.getStatus();
   }
 
   // Request APIs
@@ -66,26 +70,26 @@ export class SeerrClient {
     if (options?.sort) query.sort = options.sort;
     if (options?.sortDirection) query.sortDirection = options.sortDirection;
 
-    return SeerrApi.getRequest(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getRequest(Object.keys(query).length > 0 ? { query } : {});
   }
 
   async getRequestById(requestId: string) {
-    return SeerrApi.getRequestByRequestId({ path: { requestId } });
+    return this.api.getRequestByRequestId({ path: { requestId } });
   }
 
   async getRequestCount() {
-    return SeerrApi.getRequestCount();
+    return this.api.getRequestCount();
   }
 
   async approveRequest(requestId: string): Promise<MediaRequest> {
-    const result = await SeerrApi.postRequestByRequestIdByStatus({
+    const result = await this.api.postRequestByRequestIdByStatus({
       path: { requestId, status: 'approve' },
     });
     return result.data as MediaRequest;
   }
 
   async declineRequest(requestId: string): Promise<MediaRequest> {
-    const result = await SeerrApi.postRequestByRequestIdByStatus({
+    const result = await this.api.postRequestByRequestIdByStatus({
       path: { requestId, status: 'decline' },
     });
     return result.data as MediaRequest;
@@ -98,7 +102,7 @@ export class SeerrClient {
     if (page) searchQuery.page = page;
     if (language) searchQuery.language = language;
 
-    return SeerrApi.getSearch({ query: searchQuery });
+    return this.api.getSearch({ query: searchQuery });
   }
 
   // User APIs
@@ -113,11 +117,11 @@ export class SeerrClient {
     if (options?.skip) query.skip = options.skip;
     if (options?.sort) query.sort = options.sort;
 
-    return SeerrApi.getUser(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getUser(Object.keys(query).length > 0 ? { query } : {});
   }
 
   async getUserById(userId: number) {
-    return SeerrApi.getUserByUserId({ path: { userId } });
+    return this.api.getUserByUserId({ path: { userId } });
   }
 
   // Media APIs
@@ -127,14 +131,14 @@ export class SeerrClient {
     if (options?.take) query.take = options.take;
     if (options?.skip) query.skip = options.skip;
 
-    return SeerrApi.getMedia(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getMedia(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Update configuration
   updateConfig(newConfig: Partial<ServarrClientConfig>) {
     const updatedConfig = { ...this.clientConfig.config, ...newConfig };
     this.clientConfig = createServarrClient(updatedConfig);
-    seerrClient.setConfig({
+    this.rawClient.setConfig({
       baseUrl: `${this.clientConfig.getBaseUrl()}/api/v1`,
       headers: {
         'X-Api-Key': this.clientConfig.config.apiKey,

--- a/src/clients/sonarr.ts
+++ b/src/clients/sonarr.ts
@@ -1,6 +1,7 @@
 import { ServarrBaseClient, type ServarrOps } from '../clients/base';
+import { bindApiClient } from '../core/bind-api';
 import type { ServarrClientConfig } from '../core/types';
-import { client as sonarrClient } from '../generated/sonarr/client.gen';
+import { createClient, createConfig } from '../generated/sonarr/client';
 import * as SonarrApi from '../generated/sonarr/index';
 import type {
   CustomFormatBulkResource,
@@ -42,82 +43,85 @@ export type SonarrManualImportFilePayload = {
  * ```
  */
 export class SonarrClient extends ServarrBaseClient {
+  /** Own client instance — never the generated module singleton. See bindApiClient. */
+  private readonly api = bindApiClient(SonarrApi, this.rawClient);
+
   protected readonly ops: ServarrOps = {
     // These are overridden as methods, but required by the interface
     getSystemStatus: () => Promise.resolve(),
     getHealth: () => Promise.resolve(),
 
     // Tags
-    getTags: SonarrApi.getApiV3Tag,
-    createTag: SonarrApi.postApiV3Tag,
-    getTagById: SonarrApi.getApiV3TagById,
-    updateTagById: SonarrApi.putApiV3TagById,
-    deleteTagById: SonarrApi.deleteApiV3TagById,
-    getTagDetails: SonarrApi.getApiV3TagDetail,
-    getTagDetailById: SonarrApi.getApiV3TagDetailById,
+    getTags: this.api.getApiV3Tag,
+    createTag: this.api.postApiV3Tag,
+    getTagById: this.api.getApiV3TagById,
+    updateTagById: this.api.putApiV3TagById,
+    deleteTagById: this.api.deleteApiV3TagById,
+    getTagDetails: this.api.getApiV3TagDetail,
+    getTagDetailById: this.api.getApiV3TagDetailById,
 
     // Notifications
-    getNotifications: SonarrApi.getApiV3Notification,
-    createNotification: SonarrApi.postApiV3Notification,
-    getNotificationById: SonarrApi.getApiV3NotificationById,
-    updateNotificationById: SonarrApi.putApiV3NotificationById,
-    deleteNotificationById: SonarrApi.deleteApiV3NotificationById,
-    getNotificationSchema: SonarrApi.getApiV3NotificationSchema,
-    testNotification: SonarrApi.postApiV3NotificationTest,
-    testAllNotifications: SonarrApi.postApiV3NotificationTestall,
+    getNotifications: this.api.getApiV3Notification,
+    createNotification: this.api.postApiV3Notification,
+    getNotificationById: this.api.getApiV3NotificationById,
+    updateNotificationById: this.api.putApiV3NotificationById,
+    deleteNotificationById: this.api.deleteApiV3NotificationById,
+    getNotificationSchema: this.api.getApiV3NotificationSchema,
+    testNotification: this.api.postApiV3NotificationTest,
+    testAllNotifications: this.api.postApiV3NotificationTestall,
 
     // Download Clients
-    getDownloadClients: SonarrApi.getApiV3Downloadclient,
-    createDownloadClient: SonarrApi.postApiV3Downloadclient,
-    getDownloadClientById: SonarrApi.getApiV3DownloadclientById,
-    updateDownloadClientById: SonarrApi.putApiV3DownloadclientById,
-    deleteDownloadClientById: SonarrApi.deleteApiV3DownloadclientById,
-    getDownloadClientSchema: SonarrApi.getApiV3DownloadclientSchema,
-    testDownloadClient: SonarrApi.postApiV3DownloadclientTest,
-    testAllDownloadClients: SonarrApi.postApiV3DownloadclientTestall,
+    getDownloadClients: this.api.getApiV3Downloadclient,
+    createDownloadClient: this.api.postApiV3Downloadclient,
+    getDownloadClientById: this.api.getApiV3DownloadclientById,
+    updateDownloadClientById: this.api.putApiV3DownloadclientById,
+    deleteDownloadClientById: this.api.deleteApiV3DownloadclientById,
+    getDownloadClientSchema: this.api.getApiV3DownloadclientSchema,
+    testDownloadClient: this.api.postApiV3DownloadclientTest,
+    testAllDownloadClients: this.api.postApiV3DownloadclientTestall,
 
     // Indexers
-    getIndexers: SonarrApi.getApiV3Indexer,
-    createIndexer: SonarrApi.postApiV3Indexer,
-    getIndexerById: SonarrApi.getApiV3IndexerById,
-    updateIndexerById: SonarrApi.putApiV3IndexerById,
-    deleteIndexerById: SonarrApi.deleteApiV3IndexerById,
-    getIndexerSchema: SonarrApi.getApiV3IndexerSchema,
-    testIndexer: SonarrApi.postApiV3IndexerTest,
-    testAllIndexers: SonarrApi.postApiV3IndexerTestall,
+    getIndexers: this.api.getApiV3Indexer,
+    createIndexer: this.api.postApiV3Indexer,
+    getIndexerById: this.api.getApiV3IndexerById,
+    updateIndexerById: this.api.putApiV3IndexerById,
+    deleteIndexerById: this.api.deleteApiV3IndexerById,
+    getIndexerSchema: this.api.getApiV3IndexerSchema,
+    testIndexer: this.api.postApiV3IndexerTest,
+    testAllIndexers: this.api.postApiV3IndexerTestall,
 
     // System Admin
-    restartSystem: SonarrApi.postApiV3SystemRestart,
-    shutdownSystem: SonarrApi.postApiV3SystemShutdown,
-    getBackups: SonarrApi.getApiV3SystemBackup,
-    deleteBackup: SonarrApi.deleteApiV3SystemBackupById,
-    restoreBackup: SonarrApi.postApiV3SystemBackupRestoreById,
-    uploadBackup: SonarrApi.postApiV3SystemBackupRestoreUpload,
-    getLogFiles: SonarrApi.getApiV3LogFile,
-    getLogFileByName: SonarrApi.getApiV3LogFileByFilename,
+    restartSystem: this.api.postApiV3SystemRestart,
+    shutdownSystem: this.api.postApiV3SystemShutdown,
+    getBackups: this.api.getApiV3SystemBackup,
+    deleteBackup: this.api.deleteApiV3SystemBackupById,
+    restoreBackup: this.api.postApiV3SystemBackupRestoreById,
+    uploadBackup: this.api.postApiV3SystemBackupRestoreUpload,
+    getLogFiles: this.api.getApiV3LogFile,
+    getLogFileByName: this.api.getApiV3LogFileByFilename,
 
     // Commands
-    runCommand: SonarrApi.postApiV3Command,
-    getCommands: SonarrApi.getApiV3Command,
+    runCommand: this.api.postApiV3Command,
+    getCommands: this.api.getApiV3Command,
 
     // Host Config
-    getHostConfig: SonarrApi.getApiV3ConfigHost,
-    getHostConfigById: SonarrApi.getApiV3ConfigHostById,
-    updateHostConfig: SonarrApi.putApiV3ConfigHostById,
+    getHostConfig: this.api.getApiV3ConfigHost,
+    getHostConfigById: this.api.getApiV3ConfigHostById,
+    updateHostConfig: this.api.putApiV3ConfigHostById,
 
     // UI Config
-    getUiConfig: SonarrApi.getApiV3ConfigUi,
-    getUiConfigById: SonarrApi.getApiV3ConfigUiById,
-    updateUiConfig: SonarrApi.putApiV3ConfigUiById,
+    getUiConfig: this.api.getApiV3ConfigUi,
+    getUiConfigById: this.api.getApiV3ConfigUiById,
+    updateUiConfig: this.api.putApiV3ConfigUiById,
   };
 
   constructor(config: ServarrClientConfig) {
-    super(config, sonarrClient);
+    super(config, createClient(createConfig({ baseUrl: 'http://localhost' })));
   }
 
   // Override since Sonarr doesn't have generated system status endpoints
   async getSystemStatus() {
-    return sonarrClient.get({
+    return this.rawClient.get({
       url: '/api/v3/system/status',
       headers: this.clientConfig.getHeaders(),
       baseUrl: this.clientConfig.getBaseUrl(),
@@ -125,7 +129,7 @@ export class SonarrClient extends ServarrBaseClient {
   }
 
   async getHealth() {
-    return sonarrClient.get({
+    return this.rawClient.get({
       url: '/api/v3/health',
       headers: this.clientConfig.getHeaders(),
       baseUrl: this.clientConfig.getBaseUrl(),
@@ -134,7 +138,7 @@ export class SonarrClient extends ServarrBaseClient {
 
   // Basic API
   async getApi() {
-    return SonarrApi.getApi();
+    return this.api.getApi();
   }
 
   // Series APIs
@@ -143,28 +147,28 @@ export class SonarrClient extends ServarrBaseClient {
    * Get all TV series in the library
    */
   async getSeries() {
-    return SonarrApi.getApiV3Series();
+    return this.api.getApiV3Series();
   }
 
   /**
    * Get a specific series by ID
    */
   async getSeriesById(id: number) {
-    return SonarrApi.getApiV3SeriesById({ path: { id } });
+    return this.api.getApiV3SeriesById({ path: { id } });
   }
 
   /**
    * Add a new series to the library
    */
   async addSeries(series: SeriesResource) {
-    return SonarrApi.postApiV3Series({ body: series });
+    return this.api.postApiV3Series({ body: series });
   }
 
   /**
    * Update an existing series
    */
   async updateSeries(id: string, series: SeriesResource) {
-    return SonarrApi.putApiV3SeriesById({ path: { id }, body: series });
+    return this.api.putApiV3SeriesById({ path: { id }, body: series });
   }
 
   /**
@@ -174,7 +178,7 @@ export class SonarrClient extends ServarrBaseClient {
     id: number,
     options?: { deleteFiles?: boolean; addImportListExclusion?: boolean }
   ) {
-    return SonarrApi.deleteApiV3SeriesById({
+    return this.api.deleteApiV3SeriesById({
       path: { id },
       ...(options ? { query: options } : {}),
     });
@@ -184,7 +188,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Get series folder information
    */
   async getSeriesFolder(id: number) {
-    return SonarrApi.getApiV3SeriesByIdFolder({ path: { id } });
+    return this.api.getApiV3SeriesByIdFolder({ path: { id } });
   }
 
   // Search APIs
@@ -193,7 +197,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Search for TV series using TVDB database
    */
   async searchSeries(term: string) {
-    return SonarrApi.getApiV3SeriesLookup({ query: { term } });
+    return this.api.getApiV3SeriesLookup({ query: { term } });
   }
 
   // Root folder APIs
@@ -202,14 +206,14 @@ export class SonarrClient extends ServarrBaseClient {
    * Get all configured root folders
    */
   async getRootFolders() {
-    return SonarrApi.getApiV3Rootfolder();
+    return this.api.getApiV3Rootfolder();
   }
 
   /**
    * Add a new root folder
    */
   async addRootFolder(path: string) {
-    return SonarrApi.postApiV3Rootfolder({
+    return this.api.postApiV3Rootfolder({
       body: { path },
     });
   }
@@ -218,7 +222,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Delete a root folder by ID
    */
   async deleteRootFolder(id: number) {
-    return SonarrApi.deleteApiV3RootfolderById({ path: { id } });
+    return this.api.deleteApiV3RootfolderById({ path: { id } });
   }
 
   // Log APIs
@@ -240,7 +244,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (sortDirection) query.sortDirection = sortDirection;
     if (level) query.level = level;
 
-    return SonarrApi.getApiV3Log(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Log(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Update APIs
@@ -249,21 +253,21 @@ export class SonarrClient extends ServarrBaseClient {
    * Get available updates
    */
   async getUpdates() {
-    return SonarrApi.getApiV3Update();
+    return this.api.getApiV3Update();
   }
 
   /**
    * Get update settings
    */
   async getUpdateSettings() {
-    return SonarrApi.getApiV3Update();
+    return this.api.getApiV3Update();
   }
 
   /**
    * Get a specific update setting
    */
   async getUpdateSetting() {
-    return SonarrApi.getApiV3Update();
+    return this.api.getApiV3Update();
   }
 
   // Configuration Management APIs
@@ -272,56 +276,56 @@ export class SonarrClient extends ServarrBaseClient {
    * Get naming configuration settings
    */
   async getNamingConfig() {
-    return SonarrApi.getApiV3ConfigNaming();
+    return this.api.getApiV3ConfigNaming();
   }
 
   /**
    * Get naming configuration by ID
    */
   async getNamingConfigById(id: number) {
-    return SonarrApi.getApiV3ConfigNamingById({ path: { id } });
+    return this.api.getApiV3ConfigNamingById({ path: { id } });
   }
 
   /**
    * Update naming configuration
    */
   async updateNamingConfig(id: string, config: NamingConfigResource) {
-    return SonarrApi.putApiV3ConfigNamingById({ path: { id }, body: config });
+    return this.api.putApiV3ConfigNamingById({ path: { id }, body: config });
   }
 
   /**
    * Get naming configuration examples
    */
   async getNamingConfigExamples() {
-    return SonarrApi.getApiV3ConfigNamingExamples();
+    return this.api.getApiV3ConfigNamingExamples();
   }
 
   /**
    * Get media management configuration settings
    */
   async getMediaManagementConfig() {
-    return SonarrApi.getApiV3ConfigMediamanagement();
+    return this.api.getApiV3ConfigMediamanagement();
   }
 
   /**
    * Get media management configuration by ID
    */
   async getMediaManagementConfigById(id: number) {
-    return SonarrApi.getApiV3ConfigMediamanagementById({ path: { id } });
+    return this.api.getApiV3ConfigMediamanagementById({ path: { id } });
   }
 
   /**
    * Update media management configuration
    */
   async updateMediaManagementConfig(id: string, config: MediaManagementConfigResource) {
-    return SonarrApi.putApiV3ConfigMediamanagementById({ path: { id }, body: config });
+    return this.api.putApiV3ConfigMediamanagementById({ path: { id }, body: config });
   }
 
   /**
    * Get disk space information
    */
   async getDiskSpace() {
-    return SonarrApi.getApiV3Diskspace();
+    return this.api.getApiV3Diskspace();
   }
 
   // Episode APIs (Enhanced)
@@ -334,21 +338,21 @@ export class SonarrClient extends ServarrBaseClient {
     if (seriesId !== undefined) query.seriesId = seriesId;
     if (episodeIds !== undefined) query.episodeIds = episodeIds;
 
-    return SonarrApi.getApiV3Episode(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Episode(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get a specific episode by ID
    */
   async getEpisode(id: number) {
-    return SonarrApi.getApiV3EpisodeById({ path: { id } });
+    return this.api.getApiV3EpisodeById({ path: { id } });
   }
 
   /**
    * Update an episode
    */
   async updateEpisode(id: number, episode: EpisodeResource) {
-    return SonarrApi.putApiV3EpisodeById({ path: { id }, body: episode });
+    return this.api.putApiV3EpisodeById({ path: { id }, body: episode });
   }
 
   // Episode File APIs
@@ -361,49 +365,49 @@ export class SonarrClient extends ServarrBaseClient {
     if (seriesId !== undefined) query.seriesId = seriesId;
     if (episodeFileIds !== undefined) query.episodeFileIds = episodeFileIds;
 
-    return SonarrApi.getApiV3Episodefile(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Episodefile(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get a specific episode file by ID
    */
   async getEpisodeFile(id: number) {
-    return SonarrApi.getApiV3EpisodefileById({ path: { id } });
+    return this.api.getApiV3EpisodefileById({ path: { id } });
   }
 
   /**
    * Update an episode file
    */
   async updateEpisodeFile(id: string, episodeFile: EpisodeFileResource) {
-    return SonarrApi.putApiV3EpisodefileById({ path: { id }, body: episodeFile });
+    return this.api.putApiV3EpisodefileById({ path: { id }, body: episodeFile });
   }
 
   /**
    * Delete an episode file from disk
    */
   async deleteEpisodeFile(id: number) {
-    return SonarrApi.deleteApiV3EpisodefileById({ path: { id } });
+    return this.api.deleteApiV3EpisodefileById({ path: { id } });
   }
 
   /**
    * Bulk update episode files using the editor endpoint
    */
   async updateEpisodeFilesEditor(episodeFileList: EpisodeFileListResource) {
-    return SonarrApi.putApiV3EpisodefileEditor({ body: episodeFileList });
+    return this.api.putApiV3EpisodefileEditor({ body: episodeFileList });
   }
 
   /**
    * Bulk delete episode files
    */
   async deleteEpisodeFilesBulk(episodeFileList: EpisodeFileListResource) {
-    return SonarrApi.deleteApiV3EpisodefileBulk({ body: episodeFileList });
+    return this.api.deleteApiV3EpisodefileBulk({ body: episodeFileList });
   }
 
   /**
    * Bulk update episode files
    */
   async updateEpisodeFilesBulk(episodeFiles: EpisodeFileResource[]) {
-    return SonarrApi.putApiV3EpisodefileBulk({ body: episodeFiles });
+    return this.api.putApiV3EpisodefileBulk({ body: episodeFiles });
   }
 
   // Quality Profile APIs
@@ -412,42 +416,42 @@ export class SonarrClient extends ServarrBaseClient {
    * Get all quality profiles
    */
   async getQualityProfiles() {
-    return SonarrApi.getApiV3Qualityprofile();
+    return this.api.getApiV3Qualityprofile();
   }
 
   /**
    * Get a specific quality profile by ID
    */
   async getQualityProfile(id: number) {
-    return SonarrApi.getApiV3QualityprofileById({ path: { id } });
+    return this.api.getApiV3QualityprofileById({ path: { id } });
   }
 
   /**
    * Create a new quality profile
    */
   async addQualityProfile(profile: QualityProfileResource) {
-    return SonarrApi.postApiV3Qualityprofile({ body: profile });
+    return this.api.postApiV3Qualityprofile({ body: profile });
   }
 
   /**
    * Update an existing quality profile
    */
   async updateQualityProfile(id: string, profile: QualityProfileResource) {
-    return SonarrApi.putApiV3QualityprofileById({ path: { id }, body: profile });
+    return this.api.putApiV3QualityprofileById({ path: { id }, body: profile });
   }
 
   /**
    * Delete a quality profile
    */
   async deleteQualityProfile(id: number) {
-    return SonarrApi.deleteApiV3QualityprofileById({ path: { id } });
+    return this.api.deleteApiV3QualityprofileById({ path: { id } });
   }
 
   /**
    * Get quality profile schema
    */
   async getQualityProfileSchema() {
-    return SonarrApi.getApiV3QualityprofileSchema();
+    return this.api.getApiV3QualityprofileSchema();
   }
 
   // Custom Format APIs
@@ -456,56 +460,56 @@ export class SonarrClient extends ServarrBaseClient {
    * Get all custom formats
    */
   async getCustomFormats() {
-    return SonarrApi.getApiV3Customformat();
+    return this.api.getApiV3Customformat();
   }
 
   /**
    * Get a specific custom format by ID
    */
   async getCustomFormat(id: number) {
-    return SonarrApi.getApiV3CustomformatById({ path: { id } });
+    return this.api.getApiV3CustomformatById({ path: { id } });
   }
 
   /**
    * Create a new custom format
    */
   async addCustomFormat(format: CustomFormatResource) {
-    return SonarrApi.postApiV3Customformat({ body: format });
+    return this.api.postApiV3Customformat({ body: format });
   }
 
   /**
    * Update an existing custom format
    */
   async updateCustomFormat(id: string, format: CustomFormatResource) {
-    return SonarrApi.putApiV3CustomformatById({ path: { id }, body: format });
+    return this.api.putApiV3CustomformatById({ path: { id }, body: format });
   }
 
   /**
    * Delete a custom format
    */
   async deleteCustomFormat(id: number) {
-    return SonarrApi.deleteApiV3CustomformatById({ path: { id } });
+    return this.api.deleteApiV3CustomformatById({ path: { id } });
   }
 
   /**
    * Bulk update custom formats
    */
   async updateCustomFormatsBulk(formats: CustomFormatBulkResource) {
-    return SonarrApi.putApiV3CustomformatBulk({ body: formats });
+    return this.api.putApiV3CustomformatBulk({ body: formats });
   }
 
   /**
    * Bulk delete custom formats
    */
   async deleteCustomFormatsBulk(ids: number[]) {
-    return SonarrApi.deleteApiV3CustomformatBulk({ body: { ids } });
+    return this.api.deleteApiV3CustomformatBulk({ body: { ids } });
   }
 
   /**
    * Get custom format schema
    */
   async getCustomFormatSchema() {
-    return SonarrApi.getApiV3CustomformatSchema();
+    return this.api.getApiV3CustomformatSchema();
   }
 
   // Download Client Bulk APIs (Sonarr-specific)
@@ -514,14 +518,14 @@ export class SonarrClient extends ServarrBaseClient {
    * Bulk update download clients
    */
   async updateDownloadClientsBulk(clients: DownloadClientBulkResource) {
-    return SonarrApi.putApiV3DownloadclientBulk({ body: clients });
+    return this.api.putApiV3DownloadclientBulk({ body: clients });
   }
 
   /**
    * Bulk delete download clients
    */
   async deleteDownloadClientsBulk(ids: number[]) {
-    return SonarrApi.deleteApiV3DownloadclientBulk({ body: { ids } });
+    return this.api.deleteApiV3DownloadclientBulk({ body: { ids } });
   }
 
   // Import List APIs
@@ -530,56 +534,56 @@ export class SonarrClient extends ServarrBaseClient {
    * Get all import lists
    */
   async getImportLists() {
-    return SonarrApi.getApiV3Importlist();
+    return this.api.getApiV3Importlist();
   }
 
   /**
    * Get a specific import list by ID
    */
   async getImportList(id: number) {
-    return SonarrApi.getApiV3ImportlistById({ path: { id } });
+    return this.api.getApiV3ImportlistById({ path: { id } });
   }
 
   /**
    * Add a new import list
    */
   async addImportList(importList: ImportListResource) {
-    return SonarrApi.postApiV3Importlist({ body: importList });
+    return this.api.postApiV3Importlist({ body: importList });
   }
 
   /**
    * Update an existing import list
    */
   async updateImportList(id: number, importList: ImportListResource) {
-    return SonarrApi.putApiV3ImportlistById({ path: { id }, body: importList });
+    return this.api.putApiV3ImportlistById({ path: { id }, body: importList });
   }
 
   /**
    * Delete an import list
    */
   async deleteImportList(id: number) {
-    return SonarrApi.deleteApiV3ImportlistById({ path: { id } });
+    return this.api.deleteApiV3ImportlistById({ path: { id } });
   }
 
   /**
    * Get import list schema
    */
   async getImportListSchema() {
-    return SonarrApi.getApiV3ImportlistSchema();
+    return this.api.getApiV3ImportlistSchema();
   }
 
   /**
    * Test an import list configuration
    */
   async testImportList(importList: ImportListResource) {
-    return SonarrApi.postApiV3ImportlistTest({ body: importList });
+    return this.api.postApiV3ImportlistTest({ body: importList });
   }
 
   /**
    * Test all import lists
    */
   async testAllImportLists() {
-    return SonarrApi.postApiV3ImportlistTestall();
+    return this.api.postApiV3ImportlistTestall();
   }
 
   // History APIs
@@ -603,7 +607,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (seriesId !== undefined) query.seriesIds = [seriesId];
     if (downloadId) query.downloadId = downloadId;
 
-    return SonarrApi.getApiV3History(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3History(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -613,7 +617,7 @@ export class SonarrClient extends ServarrBaseClient {
     const query: any = { date };
     if (seriesId !== undefined) query.seriesId = seriesId;
 
-    return SonarrApi.getApiV3HistorySince({ query });
+    return this.api.getApiV3HistorySince({ query });
   }
 
   /**
@@ -624,14 +628,14 @@ export class SonarrClient extends ServarrBaseClient {
     if (seasonNumber !== undefined) query.seasonNumber = seasonNumber;
     if (eventType !== undefined) query.eventType = eventType;
 
-    return SonarrApi.getApiV3HistorySeries({ query });
+    return this.api.getApiV3HistorySeries({ query });
   }
 
   /**
    * Mark a failed download as failed in history
    */
   async markHistoryItemFailed(id: number) {
-    return SonarrApi.postApiV3HistoryFailedById({ path: { id } });
+    return this.api.postApiV3HistoryFailedById({ path: { id } });
   }
 
   // Calendar APIs
@@ -646,7 +650,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (unmonitored !== undefined) query.unmonitored = unmonitored;
     query.includeSeries = true;
 
-    return SonarrApi.getApiV3Calendar(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Calendar(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -658,7 +662,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (futureDays !== undefined) query.futureDays = futureDays;
     if (tags) query.tags = tags;
 
-    return SonarrApi.getFeedV3CalendarSonarrIcs(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getFeedV3CalendarSonarrIcs(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Queue APIs
@@ -683,7 +687,7 @@ export class SonarrClient extends ServarrBaseClient {
       query.includeUnknownSeriesItems = includeUnknownSeriesItems;
     if (seriesId !== undefined) query.seriesIds = [seriesId];
 
-    return SonarrApi.getApiV3Queue(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Queue(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -694,7 +698,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return SonarrApi.deleteApiV3QueueById({
+    return this.api.deleteApiV3QueueById({
       path: { id },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -708,7 +712,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (removeFromClient !== undefined) query.removeFromClient = removeFromClient;
     if (blocklist !== undefined) query.blocklist = blocklist;
 
-    return SonarrApi.deleteApiV3QueueBulk({
+    return this.api.deleteApiV3QueueBulk({
       body: { ids },
       ...(Object.keys(query).length > 0 ? { query } : {}),
     });
@@ -718,14 +722,14 @@ export class SonarrClient extends ServarrBaseClient {
    * Force grab a queue item
    */
   async grabQueueItem(id: number) {
-    return SonarrApi.postApiV3QueueGrabById({ path: { id } });
+    return this.api.postApiV3QueueGrabById({ path: { id } });
   }
 
   /**
    * Force grab multiple queue items
    */
   async grabQueueItemsBulk(ids: number[]) {
-    return SonarrApi.postApiV3QueueGrabBulk({ body: { ids } });
+    return this.api.postApiV3QueueGrabBulk({ body: { ids } });
   }
 
   /**
@@ -737,14 +741,14 @@ export class SonarrClient extends ServarrBaseClient {
     if (includeUnknownSeriesItems !== undefined)
       query.includeUnknownSeriesItems = includeUnknownSeriesItems;
 
-    return SonarrApi.getApiV3QueueDetails(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3QueueDetails(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Get queue status summary
    */
   async getQueueStatus() {
-    return SonarrApi.getApiV3QueueStatus();
+    return this.api.getApiV3QueueStatus();
   }
 
   // Blocklist APIs
@@ -759,21 +763,21 @@ export class SonarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return SonarrApi.getApiV3Blocklist(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Blocklist(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
    * Remove a release from the blocklist
    */
   async removeBlocklistItem(id: number) {
-    return SonarrApi.deleteApiV3BlocklistById({ path: { id } });
+    return this.api.deleteApiV3BlocklistById({ path: { id } });
   }
 
   /**
    * Bulk remove releases from the blocklist
    */
   async removeBlocklistItemsBulk(ids: number[]) {
-    return SonarrApi.deleteApiV3BlocklistBulk({ body: { ids } });
+    return this.api.deleteApiV3BlocklistBulk({ body: { ids } });
   }
 
   // Wanted/Missing APIs
@@ -793,7 +797,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return SonarrApi.getApiV3WantedMissing(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3WantedMissing(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -811,7 +815,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (sortKey) query.sortKey = sortKey;
     if (sortDirection) query.sortDirection = sortDirection;
 
-    return SonarrApi.getApiV3WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3WantedCutoff(Object.keys(query).length > 0 ? { query } : {});
   }
 
   // Parse APIs
@@ -820,7 +824,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Parse episode information from release names
    */
   async parseEpisodeInfo(title: string) {
-    return SonarrApi.getApiV3Parse({ query: { title } });
+    return this.api.getApiV3Parse({ query: { title } });
   }
 
   // Manual Import APIs
@@ -843,7 +847,7 @@ export class SonarrClient extends ServarrBaseClient {
     if (options.filterExistingFiles !== undefined)
       query.filterExistingFiles = options.filterExistingFiles;
 
-    return SonarrApi.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
+    return this.api.getApiV3Manualimport(Object.keys(query).length > 0 ? { query } : {});
   }
 
   /**
@@ -851,7 +855,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Does NOT perform the actual import — use {@link applyManualImport} for that.
    */
   async reprocessManualImport(files: ManualImportReprocessResourceWritable[]) {
-    return SonarrApi.postApiV3Manualimport({ body: files });
+    return this.api.postApiV3Manualimport({ body: files });
   }
 
   /**
@@ -876,7 +880,7 @@ export class SonarrClient extends ServarrBaseClient {
    * Get command by ID
    */
   async getCommand(id: number) {
-    return SonarrApi.getApiV3CommandById({ path: { id } });
+    return this.api.getApiV3CommandById({ path: { id } });
   }
 }
 

--- a/src/core/bind-api.ts
+++ b/src/core/bind-api.ts
@@ -1,0 +1,32 @@
+/**
+ * Binds a generated API namespace to one specific client instance.
+ *
+ * The generated `client.gen.ts` for each service exports a **module-level
+ * singleton**, and every generated operation falls back to it
+ * (`(options?.client ?? client)`). Configuring a wrapper by mutating that
+ * singleton means the last wrapper constructed wins: a second client silently
+ * rebinds the first one's base URL and credentials, so requests — and API keys
+ * — can go to the wrong server with no error.
+ *
+ * Wrapping the namespace injects a per-instance `client` into every call, so
+ * each wrapper is isolated. Call sites and types are unchanged.
+ */
+export function bindApiClient<T extends object>(api: T, client: unknown): T {
+  // Generated operations are stable, so cache the wrapper per property to keep
+  // referential equality — some clients store these references in a lookup map.
+  const bound = new Map<PropertyKey, unknown>();
+
+  return new Proxy(api, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== 'function') return value;
+
+      if (!bound.has(property)) {
+        bound.set(property, (options?: Record<string, unknown>) =>
+          (value as (o: unknown) => unknown)({ ...(options ?? {}), client })
+        );
+      }
+      return bound.get(property);
+    },
+  }) as T;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+export * from './bind-api';
 export * from './client';
 export * from './errors';
 export * from './fetch';

--- a/tests/client-isolation.test.ts
+++ b/tests/client-isolation.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  BazarrClient,
+  JellyfinClient,
+  LidarrClient,
+  ProwlarrClient,
+  QBittorrentClient,
+  RadarrClient,
+  ReadarrClient,
+  SeerrClient,
+  SonarrClient,
+} from '../src/index.js';
+
+/**
+ * Each generated client module exports a singleton that every operation falls
+ * back to. Configuring a wrapper by mutating that singleton meant the last
+ * client constructed won: a second instance silently rebound the first one's
+ * base URL and credentials, sending API keys to the wrong server with no error.
+ *
+ * These tests pin the isolation. See src/core/bind-api.ts.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+interface Captured {
+  url: string;
+  auth: string | null;
+}
+
+function captureRequests(): Captured[] {
+  const captured: Captured[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const headers = new Headers(input instanceof Request ? input.headers : (init?.headers ?? {}));
+    captured.push({
+      url,
+      auth: headers.get('authorization') ?? headers.get('x-api-key') ?? null,
+    });
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as typeof globalThis.fetch;
+  return captured;
+}
+
+const apiKeyClients: Array<
+  [string, (baseUrl: string, apiKey: string) => { getSystemStatus: () => Promise<unknown> }]
+> = [
+  ['RadarrClient', (baseUrl, apiKey) => new RadarrClient({ baseUrl, apiKey })],
+  ['SonarrClient', (baseUrl, apiKey) => new SonarrClient({ baseUrl, apiKey })],
+  ['LidarrClient', (baseUrl, apiKey) => new LidarrClient({ baseUrl, apiKey })],
+  ['ReadarrClient', (baseUrl, apiKey) => new ReadarrClient({ baseUrl, apiKey })],
+  ['ProwlarrClient', (baseUrl, apiKey) => new ProwlarrClient({ baseUrl, apiKey })],
+  ['BazarrClient', (baseUrl, apiKey) => new BazarrClient({ baseUrl, apiKey })],
+  ['SeerrClient', (baseUrl, apiKey) => new SeerrClient({ baseUrl, apiKey })],
+  ['JellyfinClient', (baseUrl, apiKey) => new JellyfinClient({ baseUrl, apiKey })],
+];
+
+describe('client instance isolation', () => {
+  for (const [name, create] of apiKeyClients) {
+    it(`${name} does not leak config to another instance`, async () => {
+      const captured = captureRequests();
+
+      const alpha = create('http://alpha', 'KEY-ALPHA');
+      // Constructing beta must not rebind alpha.
+      const beta = create('http://beta', 'KEY-BETA');
+
+      await alpha.getSystemStatus();
+      await beta.getSystemStatus();
+
+      expect(captured).toHaveLength(2);
+      expect(captured[0].url).toContain('alpha');
+      expect(captured[1].url).toContain('beta');
+      expect(captured[0].url).not.toContain('beta');
+    });
+
+    it(`${name} sends each instance its own credential`, async () => {
+      const captured = captureRequests();
+
+      const alpha = create('http://alpha', 'KEY-ALPHA');
+      create('http://beta', 'KEY-BETA');
+      await alpha.getSystemStatus();
+
+      expect(captured).toHaveLength(1);
+      // A credential leak is the dangerous half of this bug: the wrong server
+      // receiving a key it should never see.
+      expect(captured[0].auth ?? '').toContain('KEY-ALPHA');
+      expect(captured[0].auth ?? '').not.toContain('KEY-BETA');
+    });
+  }
+
+  it('QBittorrentClient does not leak config to another instance', async () => {
+    const captured = captureRequests();
+
+    const alpha = new QBittorrentClient({
+      baseUrl: 'http://alpha',
+      username: 'a',
+      password: 'a',
+    });
+    new QBittorrentClient({ baseUrl: 'http://beta', username: 'b', password: 'b' });
+
+    await alpha.getSystemStatus();
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured.every(c => c.url.includes('alpha'))).toBe(true);
+  });
+
+  it('updateConfig on one client does not affect another', async () => {
+    const captured = captureRequests();
+
+    const alpha = new JellyfinClient({ baseUrl: 'http://alpha', apiKey: 'KEY-ALPHA' });
+    const beta = new JellyfinClient({ baseUrl: 'http://beta', apiKey: 'KEY-BETA' });
+
+    beta.updateConfig({ baseUrl: 'http://gamma' });
+    await alpha.getSystemStatus();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toContain('alpha');
+  });
+});

--- a/tests/clients-unit.test.ts
+++ b/tests/clients-unit.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'bun:test';
 import { ApiKeyError, ConnectionError } from '../src/core/errors.js';
-import { client as bazarrApiClient } from '../src/generated/bazarr/client.gen.js';
 import {
   BazarrClient,
   LidarrClient,
@@ -454,24 +453,44 @@ describe('Client Unit Tests', () => {
       expect(client).toBeInstanceOf(BazarrClient);
     });
 
-    it('should configure the raw client without /api prefix (SDK paths include it)', () => {
-      new BazarrClient(validConfig);
-      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767');
+    // Asserted through the outgoing request rather than the generated client's
+    // config: each wrapper now owns its client, so there is no shared singleton
+    // to inspect. See tests/client-isolation.test.ts.
+    async function captureRequest(client: BazarrClient) {
+      const originalFetch = globalThis.fetch;
+      let captured: { url: string; auth: string | null } | null = null;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const headers = new Headers(
+          input instanceof Request ? input.headers : (init?.headers ?? {})
+        );
+        captured = { url, auth: headers.get('x-api-key') ?? headers.get('authorization') };
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }) as typeof globalThis.fetch;
+      try {
+        await client.getSystemStatus();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+      return captured as { url: string; auth: string | null } | null;
+    }
+
+    it('should not double up the /api prefix (SDK paths include it)', async () => {
+      const captured = await captureRequest(new BazarrClient(validConfig));
+      expect(captured?.url.startsWith('http://localhost:6767/api/')).toBe(true);
+      expect(captured?.url).not.toContain('/api/api/');
     });
 
-    it('should strip /api suffix when user includes it in base URL', () => {
-      new BazarrClient({
-        baseUrl: 'http://localhost:6767/api',
-        apiKey: validConfig.apiKey,
-      });
-
-      expect(bazarrApiClient.getConfig().baseUrl).toBe('http://localhost:6767');
+    it('should strip /api suffix when user includes it in base URL', async () => {
+      const captured = await captureRequest(
+        new BazarrClient({ baseUrl: 'http://localhost:6767/api', apiKey: validConfig.apiKey })
+      );
+      expect(captured?.url).not.toContain('/api/api/');
     });
 
-    it('should configure generated auth for Bazarr requests', () => {
-      new BazarrClient(validConfig);
-
-      expect(bazarrApiClient.getConfig().auth).toBe(validConfig.apiKey);
+    it('should send the API key on Bazarr requests', async () => {
+      const captured = await captureRequest(new BazarrClient(validConfig));
+      expect(captured?.auth).toBe(validConfig.apiKey);
     });
 
     it('should have all required methods', () => {


### PR DESCRIPTION
Fixes #240.

## The bug

Every generated client module exports a **singleton** that all its operations fall back to (`options?.client ?? client`). All nine wrappers configured themselves by mutating that singleton, so the last one constructed won:

```ts
const a = new RadarrClient({ baseUrl: 'http://radarr-1', apiKey: 'R1' });
const b = new RadarrClient({ baseUrl: 'http://radarr-2', apiKey: 'R2' });
await a.getSystemStatus();   // → http://radarr-2 with key R2
```

Requests — and the **API keys attached to them** — silently went to the wrong server, with no error. That credential leak is the dangerous half: a key for one server sent to another.

The CLI was unaffected (one client per invocation), but this broke the multi-instance SDK usage tsarr documents in `docs/cli.md`.

## The fix

Each wrapper now creates its own client and binds the generated API namespace to it through `bindApiClient()` (`src/core/bind-api.ts`), which injects a per-instance `client` into every call via a `Proxy`. **Call sites and public types are unchanged** — no API break.

Before / after, all nine clients:

```
❌ RadarrClient      first call → http://beta/api/v3/system/status
✅ RadarrClient      first call → http://alpha/api/v3/system/status
...
9/9 clients correctly isolated
```

## Also in here

- **`RawClient` gains `get`** — Sonarr calls the raw client directly for two endpoints its OpenAPI spec omits.
- **Three Bazarr unit tests rewritten.** They asserted on the shared singleton's `getConfig()`, i.e. they pinned the broken behaviour. They now assert on the outgoing request, which is what actually matters.

## Tests

`tests/client-isolation.test.ts` — 18 tests across all nine clients covering base-URL separation, credential separation, and `updateConfig` cross-talk.

Verified these actually catch the regression rather than passing vacuously: restoring the old `seerr.ts` turns them red.

```
(fail) client instance isolation > SeerrClient does not leak config to another instance
(fail) client instance isolation > SeerrClient sends each instance its own credential
 16 pass, 2 fail
```

## Checks

`lint` ✅ · `typecheck` ✅ · `type-coverage` 98.40% ✅ · `bun test` 338/338 ✅ · `build` ✅

Also re-run against a real Jellyfin server, since a `Proxy` over the SDK could break actual calls in ways unit tests would not catch: **32/32 integration, 55/55 CLI smoke**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for direct Sonarr requests to endpoints not covered by the standard API definition.
  * Service integrations now maintain independent connection settings, including server addresses and credentials.

* **Bug Fixes**
  * Prevented configuration changes in one service connection from affecting other connections.
  * Improved API URL handling and authentication behavior for Bazarr requests.

* **Tests**
  * Added coverage validating independent configurations and request-level authentication across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->