### PR TITLE
feat(jellyfin): add artwork commands for fixing missing or poor covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   <br />
 
-  <img src="./docs/vhs/hero.gif" alt="tsarr doctor — eight services, one terminal" />
+  <img src="./docs/vhs/hero.gif" alt="tsarr doctor — your whole media stack in one terminal" />
 
 </div>
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -375,6 +375,11 @@ tsarr jellyfin <resource> <action> [args]
 | `item` | `latest` | `--user <v> [--limit <n>]` | List recently added items |
 | `item` | `nextup` | `--user <v> [--limit <n>]` | List next-up episodes |
 | `item` | `resume` | `--user <v> [--limit <n>]` | List in-progress (resumable) items |
+| `image` | `list` | `--id <v>` | Artwork an item has, with dimensions — use to spot missing or poor covers |
+| `image` | `remote` | `--id <v> [--type <v>] [--provider <v>] [--all-languages] [--limit <n>]` | Artwork candidates from metadata providers |
+| `image` | `providers` | `--id <v>` | Artwork providers available for an item |
+| `image` | `set` | `--id <v> --type <v> --url <v>` | Attach artwork from a URL, replacing the existing image |
+| `image` | `delete` | `--id <v> --type <v> [--index <n>]` | Remove artwork (confirms) |
 | `watched` | `status` | `--id <v> --user <v>` | Show watched state for an item |
 | `watched` | `mark` | `--id <v> --user <v>` | Mark an item as played |
 | `watched` | `unmark` | `--id <v> --user <v>` | Mark an item as unplayed |
@@ -410,6 +415,13 @@ tsarr jellyfin <resource> <action> [args]
 
 Jellyfin returns PascalCase JSON, so table columns and `--select` use PascalCase
 field names (`Id`, `Name`, `Type`) rather than the camelCase used by Servarr services.
+
+**Artwork:** `image set --url` accepts any reachable image URL, not just the
+candidates from `image remote`. Note that `image remote` reports `Width`/`Height`
+on Jellyfin 10.11 but **not on 12.0**, even though the API schema declares them —
+rank candidates by `CommunityRating` when dimensions are absent. The image
+*serving* endpoints (`GET /Items/{id}/Images/...`, which return raw bytes) are
+deliberately not wrapped.
 
 **Not available:** there is no `playlist get` or `playlist move`. Jellyfin's
 `GetPlaylist` and `MoveItem` endpoints require a user-context token and expose no

--- a/docs/cli-getting-started.md
+++ b/docs/cli-getting-started.md
@@ -5,7 +5,7 @@ group: CLI
 
 # CLI Getting Started
 
-TsArr includes a command-line interface for interacting with Servarr services directly from your terminal.
+TsArr includes a command-line interface for interacting with your media stack directly from your terminal — Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, qBittorrent, Seerr and Jellyfin.
 
 ## Installation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -745,6 +745,13 @@ tsarr jellyfin item latest --user <userId>     # Recently added
 tsarr jellyfin item nextup --user <userId>     # Next-up episodes
 tsarr jellyfin item resume --user <userId>     # In-progress items
 
+# Artwork — fix a missing or poor cover
+tsarr jellyfin image list --id <itemId>              # what artwork exists, with dimensions
+tsarr jellyfin image remote --id <itemId> --type Primary --limit 10
+tsarr jellyfin image set --id <itemId> --type Primary --url "<url>"
+tsarr jellyfin image delete --id <itemId> --type Primary
+tsarr jellyfin image providers --id <itemId>
+
 # Watched state
 tsarr jellyfin watched status --id <itemId> --user <userId>
 tsarr jellyfin watched mark --id <itemId> --user <userId>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-This guide provides comprehensive documentation for using the TsArr TypeScript SDK to interact with Servarr APIs.
+This guide provides comprehensive documentation for using the TsArr TypeScript SDK to interact with Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, qBittorrent, Seerr and Jellyfin.
 
 ## Installation
 
@@ -364,6 +364,10 @@ const devRadarr = new RadarrClient({
   apiKey: process.env.DEV_RADARR_API_KEY!
 });
 ```
+
+Every client owns its configuration, so instances of the same service never
+interfere with each other — `prodRadarr` keeps its base URL and API key when
+`devRadarr` is constructed. The same holds for `updateConfig()` on one instance.
 
 ### Custom Headers and Options
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
       "types": "./dist/clients/jellyfin-types.d.ts"
     }
   },
-  "description": "Type-safe TypeScript SDK for Servarr APIs (Radarr, Sonarr, etc.)",
+  "description": "Type-safe TypeScript SDK and CLI for your media stack (Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, qBittorrent, Seerr, Jellyfin)",
   "engines": {
     "node": ">=24.18.0"
   },

--- a/scripts/jellyfin-smoke.ts
+++ b/scripts/jellyfin-smoke.ts
@@ -244,6 +244,92 @@ for (const target of TARGETS) {
     ]);
   }
 
+  // ---- artwork ------------------------------------------------------------
+  if (movieId) {
+    check(
+      'image list',
+      ['jellyfin', 'image', 'list', '--id', movieId, '--json'],
+      expectField('ImageType')
+    );
+    const remoteOut = check('image remote', [
+      'jellyfin',
+      'image',
+      'remote',
+      '--id',
+      movieId,
+      '--type',
+      'Primary',
+      '--limit',
+      '5',
+      '--json',
+    ]);
+    const candidates = json(remoteOut ?? '[]') ?? [];
+    check('image providers', ['jellyfin', 'image', 'providers', '--id', movieId, '--json']);
+
+    if (candidates.length) {
+      // Rank by resolution where the server reports it (10.11) and by rating
+      // otherwise (12.0 omits Width/Height).
+      const ranked = [...candidates].sort((a: any, b: any) =>
+        typeof a.Width === 'number'
+          ? (b.Width ?? 0) - (a.Width ?? 0)
+          : (b.CommunityRating ?? 0) - (a.CommunityRating ?? 0)
+      );
+      check('image set from url', [
+        'jellyfin',
+        'image',
+        'set',
+        '--id',
+        movieId,
+        '--type',
+        'Primary',
+        '--url',
+        ranked[0].Url,
+      ]);
+      check(
+        'image list shows the new cover',
+        ['jellyfin', 'image', 'list', '--id', movieId, '--json'],
+        stdout => {
+          const images = json(stdout) ?? [];
+          return images.some((i: any) => i.ImageType === 'Primary')
+            ? null
+            : 'Primary missing after set';
+        }
+      );
+      check('image delete', [
+        'jellyfin',
+        'image',
+        'delete',
+        '--id',
+        movieId,
+        '--type',
+        'Primary',
+        '--yes',
+      ]);
+      check(
+        'image list shows it gone',
+        ['jellyfin', 'image', 'list', '--id', movieId, '--json'],
+        stdout => {
+          const images = json(stdout) ?? [];
+          return images.some((i: any) => i.ImageType === 'Primary')
+            ? 'Primary still present'
+            : null;
+        }
+      );
+      // Put it back so reruns start from a known state.
+      cli([
+        'jellyfin',
+        'image',
+        'set',
+        '--id',
+        movieId,
+        '--type',
+        'Primary',
+        '--url',
+        ranked[0].Url,
+      ]);
+    }
+  }
+
   // ---- search -------------------------------------------------------------
   check(
     'search query',

--- a/skills/tsarr/SKILL.md
+++ b/skills/tsarr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsarr
-description: Manage home media services through TsArr from OpenClaw. Use for Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, qBittorrent, Seerr, and Jellyfin tasks such as checking health, inspecting queues and history, browsing libraries, searching, adding, editing, deleting items, viewing profiles, tags, and root folders, managing torrents, managing media requests, triggering library scans, reading watched state, checking active playback sessions, and checking TsArr configuration.
+description: Manage home media services through TsArr from OpenClaw. Use for Radarr, Sonarr, Lidarr, Readarr, Prowlarr, Bazarr, qBittorrent, Seerr, and Jellyfin tasks such as checking health, inspecting queues and history, browsing libraries, searching, adding, editing, deleting items, viewing profiles, tags, and root folders, managing torrents, managing media requests, triggering library scans, reading watched state, checking active playback sessions, fixing missing or poor cover images, and checking TsArr configuration.
 metadata:
   openclaw:
     requires:

--- a/skills/tsarr/references/common-workflows.md
+++ b/skills/tsarr/references/common-workflows.md
@@ -197,6 +197,58 @@ Jellyfin output is PascalCase, so extract fields accordingly:
 tsarr jellyfin item list --type Movie --json --select Id,Name
 ```
 
+## Fix a missing or poor cover image
+
+When someone says a title has no cover, or a bad one, resolve it in four steps.
+Never guess an item ID — look it up.
+
+```bash
+# 1. Find the item
+tsarr jellyfin item list --search "Pokemon" --type Movie --json --select Id,Name,ProductionYear
+
+# 2. Inspect what artwork it has. No Primary row means no cover; a small
+#    Width/Height means a poor one.
+tsarr jellyfin image list --id <itemId> --json
+
+# 3. List candidates from the metadata providers
+tsarr jellyfin image remote --id <itemId> --type Primary --limit 10 --json
+
+# 4. Apply the chosen one
+tsarr jellyfin image set --id <itemId> --type Primary --url "<url>"
+```
+
+Choosing a candidate:
+
+- Prefer higher `Width`/`Height`, then higher `CommunityRating`.
+- **`Width`/`Height` are absent on Jellyfin 12.0** (present on 10.11), even
+  though the API schema declares them. When they are missing, rank by
+  `CommunityRating` and `VoteCount` instead.
+- `Language` matters for posters with title text; pass `--all-languages` to
+  widen the search.
+
+`--url` accepts **any reachable image URL**, not only provider candidates, so a
+cover found elsewhere can be applied directly:
+
+```bash
+tsarr jellyfin image set --id <itemId> --type Primary --url "https://example.com/poster.jpg"
+```
+
+Other artwork types work the same way — `Backdrop`, `Logo`, `Thumb`, `Banner`.
+To drop a bad image without replacing it:
+
+```bash
+tsarr jellyfin image delete --id <itemId> --type Primary --yes
+```
+
+To sweep a whole library for missing covers:
+
+```bash
+for id in $(tsarr jellyfin item list --type Movie --quiet); do
+  tsarr jellyfin image list --id "$id" --json \
+    | grep -q '"Primary"' || echo "no cover: $id"
+done
+```
+
 ## Configuration checks
 
 When a command fails unexpectedly, inspect TsArr’s merged configuration:

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -162,39 +162,73 @@ Seerr uses API key authentication. Configure via `tsarr config init` or environm
 
 ## Jellyfin
 
-Use for media server tasks: trigger library scans, read watched state, and check who is streaming.
+Use for media server tasks: trigger library scans, read watched state, see who is streaming, control playback, manage playlists and collections, and fix artwork.
+
+Full command surface:
 
 ```bash
-tsarr jellyfin system status --json
 tsarr jellyfin library refresh
-tsarr jellyfin library folders --json
-tsarr jellyfin item list --type Movie --json
-tsarr jellyfin item list --search "The Matrix" --limit 10 --json
-tsarr jellyfin item counts --json
-tsarr jellyfin item get --id <itemId> --user <userId> --json
-tsarr jellyfin watched status --id <itemId> --user <userId> --json
-tsarr jellyfin watched mark --id <itemId> --user <userId>
-tsarr jellyfin image list --id <itemId> --json
-tsarr jellyfin image remote --id <itemId> --type Primary --json
-tsarr jellyfin image set --id <itemId> --type Primary --url "<url>"
-tsarr jellyfin session list --json
-tsarr jellyfin session pause --id <sessionId>
-tsarr jellyfin session message --id <sessionId> --text "Maintenance in 5 minutes"
-tsarr jellyfin playlist create --name "Friday" --user <userId> --json
-tsarr jellyfin playlist items --id <playlistId> --user <userId> --json
-tsarr jellyfin collection create --name "Sci-Fi" --items <a,b> --json
-tsarr jellyfin user list --json
-tsarr jellyfin task list --json
-tsarr jellyfin search query --query "The Matrix" --json
+tsarr jellyfin library folders
+tsarr jellyfin library add --name <name> [--collection-type <collection-type>] [--paths <paths>] [--refresh]
+tsarr jellyfin library remove --name <name>
+tsarr jellyfin item list [--search <search>] [--type <type>] [--parent <parent>] [--user <user>] [--played] [--limit <limit>]
+tsarr jellyfin item get --id <id> --user <user>
+tsarr jellyfin item refresh --id <id> [--mode <mode>] [--replace-metadata] [--replace-images]
+tsarr jellyfin item delete --id <id>
+tsarr jellyfin item counts [--user <user>]
+tsarr jellyfin item latest --user <user> [--limit <limit>]
+tsarr jellyfin item nextup --user <user> [--limit <limit>]
+tsarr jellyfin item resume --user <user> [--limit <limit>]
+tsarr jellyfin image list --id <id>
+tsarr jellyfin image remote --id <id> [--type <type>] [--provider <provider>] [--all-languages] [--limit <limit>]
+tsarr jellyfin image providers --id <id>
+tsarr jellyfin image set --id <id> --type <type> --url <url>
+tsarr jellyfin image delete --id <id> --type <type> [--index <index>]
+tsarr jellyfin watched status --id <id> --user <user>
+tsarr jellyfin watched mark --id <id> --user <user>
+tsarr jellyfin watched unmark --id <id> --user <user>
+tsarr jellyfin watched favorite --id <id> --user <user>
+tsarr jellyfin watched unfavorite --id <id> --user <user>
+tsarr jellyfin session list [--active-within <active-within>]
+tsarr jellyfin session play --id <id> --items <a,b> [--mode <mode>] [--position <position>]
+tsarr jellyfin session pause --id <id>
+tsarr jellyfin session unpause --id <id>
+tsarr jellyfin session stop --id <id>
+tsarr jellyfin session seek --id <id> --position <position>
+tsarr jellyfin session message --id <id> --text <text> [--header <header>] [--timeout <timeout>]
+tsarr jellyfin session command --id <id> --command <command>
+tsarr jellyfin session system --id <id> --command <command>
+tsarr jellyfin session display --id <id> --item <item> --name <name> --type <type>
+tsarr jellyfin session add-user --id <id> --user <user>
+tsarr jellyfin session remove-user --id <id> --user <user>
+tsarr jellyfin playlist create --name <name> --user <user> [--items <a,b>] [--type <type>]
+tsarr jellyfin playlist items --id <id> --user <user> [--limit <limit>]
+tsarr jellyfin playlist add --id <id> --items <a,b> --user <user>
+tsarr jellyfin playlist remove --id <id> --entries <a,b>
+tsarr jellyfin collection create --name <name> [--items <a,b>] [--parent <parent>]
+tsarr jellyfin collection add --id <id> --items <a,b>
+tsarr jellyfin collection remove --id <id> --items <a,b>
+tsarr jellyfin user list
+tsarr jellyfin user get --id <id>
+tsarr jellyfin task list
+tsarr jellyfin task start --id <id>
+tsarr jellyfin task stop --id <id>
+tsarr jellyfin search query --query <query> [--type <type>] [--limit <limit>]
+tsarr jellyfin system status
+tsarr jellyfin system activity [--limit <limit>]
 ```
+
+Add `--json` to any command when extracting values.
 
 Jellyfin uses API key authentication. Configure via `tsarr config init` or environment variables `TSARR_JELLYFIN_URL` and `TSARR_JELLYFIN_API_KEY`. Get a key from Dashboard -> Advanced -> API Keys.
 
-Playlists are user-owned: `playlist create`, `items` and `add` all require `--user`. There is no `playlist get` or `playlist move` — those Jellyfin endpoints need a user-context token and reject API keys; use `tsarr jellyfin item get --id <playlistId> --user <userId>` instead.
-
 **Important:** Jellyfin returns PascalCase JSON (`Id`, `Name`, `Type`, `Items`), unlike the camelCase used by the Servarr services. Use PascalCase when parsing output or passing `--select`.
 
-`--user <userId>` is **required** on `item get`, `item latest`, `item nextup`, `item resume` and all `watched` commands. Jellyfin's spec marks it optional but the server returns 400 without it. Get IDs from `tsarr jellyfin user list --json`.
+`--user <userId>` is **required** on `item get`, `item latest`, `item nextup`, `item resume` and all `watched` and `playlist` commands. Jellyfin's spec marks it optional but the server returns 400 without it. Get IDs from `tsarr jellyfin user list --json`.
+
+There is no `playlist get` or `playlist move` — those Jellyfin endpoints need a user-context token and reject API keys; use `tsarr jellyfin item get --id <playlistId> --user <userId>` instead.
+
+See "Fix a missing or poor cover image" in common-workflows.md for the artwork workflow.
 
 ## Multi-instance services
 

--- a/skills/tsarr/references/service-cheatsheet.md
+++ b/skills/tsarr/references/service-cheatsheet.md
@@ -174,6 +174,9 @@ tsarr jellyfin item counts --json
 tsarr jellyfin item get --id <itemId> --user <userId> --json
 tsarr jellyfin watched status --id <itemId> --user <userId> --json
 tsarr jellyfin watched mark --id <itemId> --user <userId>
+tsarr jellyfin image list --id <itemId> --json
+tsarr jellyfin image remote --id <itemId> --type Primary --json
+tsarr jellyfin image set --id <itemId> --type Primary --url "<url>"
 tsarr jellyfin session list --json
 tsarr jellyfin session pause --id <sessionId>
 tsarr jellyfin session message --id <sessionId> --text "Maintenance in 5 minutes"

--- a/src/cli/commands/jellyfin.ts
+++ b/src/cli/commands/jellyfin.ts
@@ -73,6 +73,22 @@ const GENERAL_COMMANDS = [
   'SetPlaybackOrder',
 ];
 
+const IMAGE_TYPES = [
+  'Primary',
+  'Art',
+  'Backdrop',
+  'Banner',
+  'Logo',
+  'Thumb',
+  'Disc',
+  'Box',
+  'Screenshot',
+  'Menu',
+  'Chapter',
+  'BoxRear',
+  'Profile',
+];
+
 /** Jellyfin measures playback positions in .NET ticks: 10,000,000 per second. */
 const TICKS_PER_SECOND = 10_000_000;
 
@@ -272,6 +288,88 @@ export const resources: ResourceDef[] = [
           const items = unwrapItems(result);
           return Array.isArray(items) ? limitResults(items, a.limit) : result;
         },
+      },
+    ],
+  },
+  {
+    name: 'image',
+    description: 'Inspect and replace artwork',
+    actions: [
+      {
+        name: 'list',
+        description: "Show an item's current artwork and its dimensions",
+        args: [{ name: 'id', description: 'Item ID', required: true }],
+        columns: ['ImageType', 'ImageIndex', 'Width', 'Height', 'Size'],
+        idField: 'ImageType',
+        run: (c: JellyfinClient, a) => c.getItemImages(a.id),
+      },
+      {
+        name: 'remote',
+        description: 'List artwork candidates from metadata providers',
+        args: [
+          { name: 'id', description: 'Item ID', required: true },
+          {
+            name: 'type',
+            description: `Image type (${IMAGE_TYPES.slice(0, 6).join('|')}...)`,
+            values: IMAGE_TYPES,
+          },
+          { name: 'provider', description: 'Only this provider (e.g. TheMovieDb)' },
+          { name: 'all-languages', description: 'Include all languages', type: 'boolean' },
+          { name: 'limit', description: 'Maximum number of candidates', type: 'number' },
+        ],
+        columns: ['ProviderName', 'Width', 'Height', 'Language', 'CommunityRating', 'Url'],
+        idField: 'Url',
+        run: async (c: JellyfinClient, a) => {
+          const result: any = await c.getRemoteImages(a.id, a.type, {
+            ...(a.provider ? { providerName: a.provider } : {}),
+            ...(a['all-languages'] !== undefined
+              ? { includeAllLanguages: a['all-languages'] }
+              : {}),
+            ...(a.limit ? { limit: a.limit } : {}),
+          });
+          const data = result?.data ?? result;
+          const images = data?.Images;
+          if (!Array.isArray(images)) return result;
+          return limitResults(images, a.limit);
+        },
+      },
+      {
+        name: 'providers',
+        description: 'List artwork providers available for an item',
+        args: [{ name: 'id', description: 'Item ID', required: true }],
+        columns: ['Name'],
+        idField: 'Name',
+        run: (c: JellyfinClient, a) => c.getRemoteImageProviders(a.id),
+      },
+      {
+        name: 'set',
+        description: 'Attach artwork to an item from a URL (replaces the existing image)',
+        args: [
+          { name: 'id', description: 'Item ID', required: true },
+          {
+            name: 'type',
+            description: 'Image type',
+            required: true,
+            values: IMAGE_TYPES,
+          },
+          {
+            name: 'url',
+            description: 'Image URL. Any reachable URL works, not just provider candidates',
+            required: true,
+          },
+        ],
+        run: (c: JellyfinClient, a) => c.downloadRemoteImage(a.id, a.type, a.url),
+      },
+      {
+        name: 'delete',
+        description: 'Remove artwork from an item',
+        args: [
+          { name: 'id', description: 'Item ID', required: true },
+          { name: 'type', description: 'Image type', required: true, values: IMAGE_TYPES },
+          { name: 'index', description: 'Image index', type: 'number' },
+        ],
+        confirmMessage: 'Remove this artwork?',
+        run: (c: JellyfinClient, a) => c.deleteItemImage(a.id, a.type, a.index),
       },
     ],
   },

--- a/src/cli/completions.ts
+++ b/src/cli/completions.ts
@@ -66,6 +66,7 @@ const SERVICE_COMMANDS: Record<string, Record<string, string[]>> = {
   jellyfin: {
     library: ['refresh', 'folders', 'add', 'remove'],
     item: ['list', 'get', 'refresh', 'delete', 'counts', 'latest', 'nextup', 'resume'],
+    image: ['list', 'remote', 'providers', 'set', 'delete'],
     watched: ['status', 'mark', 'unmark', 'favorite', 'unfavorite'],
     session: [
       'list',

--- a/src/clients/jellyfin.ts
+++ b/src/clients/jellyfin.ts
@@ -14,6 +14,7 @@ import type {
   GetLogEntriesData,
   GetNextUpData,
   GetPlaylistItemsData,
+  GetRemoteImagesData,
   GetResumeItemsData,
   GetSearchHintsData,
   GetSessionsData,
@@ -53,6 +54,8 @@ type PlaylistMediaType = NonNullable<NonNullable<CreatePlaylistData['query']>['m
 type PlaylistItemsQuery = NonNullable<GetPlaylistItemsData['query']>;
 type AddToPlaylistQuery = NonNullable<AddItemToPlaylistData['query']>;
 type CollectionQuery = NonNullable<CreateCollectionData['query']>;
+type ImageType = NonNullable<NonNullable<GetRemoteImagesData['query']>['type']>;
+type RemoteImagesQuery = Omit<NonNullable<GetRemoteImagesData['query']>, 'type'>;
 
 /**
  * Jellyfin API client for media server management
@@ -369,6 +372,54 @@ export class JellyfinClient {
 
   async removeFromCollection(collectionId: string, ids: string[]) {
     return this.api.removeFromCollection({ path: { collectionId }, query: { ids } });
+  }
+
+  // Artwork APIs
+  //
+  // Only image *management* is wrapped. The many `GET /Items/{id}/Images/...`
+  // variants serve raw JPEG/PNG bytes and have no useful CLI or SDK shape.
+
+  /** Which images an item already has, with dimensions — use to spot missing or low-quality artwork. */
+  async getItemImages(itemId: string) {
+    return this.api.getItemImageInfos({ path: { itemId } });
+  }
+
+  /**
+   * Artwork candidates from metadata providers, with language and community
+   * rating so a caller can pick a good one.
+   *
+   * Note: 10.11 reports `Width`/`Height` per candidate but **12.0 does not**,
+   * even though the OpenAPI schema still declares them. Code that ranks
+   * candidates by resolution must fall back to `CommunityRating`.
+   */
+  async getRemoteImages(itemId: string, type?: ImageType, options?: RemoteImagesQuery) {
+    return this.api.getRemoteImages({
+      path: { itemId },
+      query: { ...(type ? { type } : {}), ...(options ?? {}) },
+    });
+  }
+
+  async getRemoteImageProviders(itemId: string) {
+    return this.api.getRemoteImageProviders({ path: { itemId } });
+  }
+
+  /**
+   * Attach an image to an item from a URL, replacing any existing image of that
+   * type. The URL does not have to come from `getRemoteImages` — any reachable
+   * image URL works.
+   */
+  async downloadRemoteImage(itemId: string, type: ImageType, imageUrl?: string) {
+    return this.api.downloadRemoteImage({
+      path: { itemId },
+      query: { type, ...(imageUrl ? { imageUrl } : {}) },
+    });
+  }
+
+  async deleteItemImage(itemId: string, imageType: ImageType, imageIndex?: number) {
+    return this.api.deleteItemImage({
+      path: { itemId, imageType },
+      ...(imageIndex !== undefined ? { query: { imageIndex } } : {}),
+    });
   }
 
   // Update configuration

--- a/tests/cli-command-defs.test.ts
+++ b/tests/cli-command-defs.test.ts
@@ -166,6 +166,7 @@ describe('Jellyfin command definitions', () => {
     expect(jellyfinResources.map(r => r.name)).toEqual([
       'library',
       'item',
+      'image',
       'watched',
       'session',
       'playlist',
@@ -205,6 +206,27 @@ describe('Jellyfin command definitions', () => {
 
     const collection = jellyfinResources.find(r => r.name === 'collection');
     expect(collection!.actions.map(a => a.name)).toEqual(['create', 'add', 'remove']);
+  });
+
+  it('defines the image resource for inspecting and replacing artwork', () => {
+    const image = jellyfinResources.find(r => r.name === 'image');
+    expect(image).toBeDefined();
+    expect(image!.actions.map(a => a.name)).toEqual([
+      'list',
+      'remote',
+      'providers',
+      'set',
+      'delete',
+    ]);
+    // Dimensions are how a caller judges whether a cover is missing or poor.
+    expect(getAction(jellyfinResources, 'image', 'list').columns).toEqual([
+      'ImageType',
+      'ImageIndex',
+      'Width',
+      'Height',
+      'Size',
+    ]);
+    expect(getAction(jellyfinResources, 'image', 'remote').columns).toContain('CommunityRating');
   });
 
   it('requires a user id for user-owned playlist operations', () => {

--- a/tests/integration-jellyfin.test.ts
+++ b/tests/integration-jellyfin.test.ts
@@ -200,6 +200,75 @@ for (const target of TARGETS) {
       });
     });
 
+    describe('artwork', () => {
+      it('reports the artwork an item currently has, with dimensions', async () => {
+        const list = unwrap(
+          await jellyfin.getItems({ includeItemTypes: ['Movie'], recursive: true, limit: 1 })
+        );
+        const images = unwrap(await jellyfin.getItemImages(list.Items[0].Id));
+
+        expect(Array.isArray(images)).toBe(true);
+        // Dimensions are what lets a caller judge "this cover is bad".
+        for (const image of images) {
+          expect(typeof image.ImageType).toBe('string');
+          expect(typeof image.Width).toBe('number');
+          expect(typeof image.Height).toBe('number');
+        }
+      });
+
+      it('offers remote artwork candidates with the fields needed to choose', async () => {
+        const list = unwrap(
+          await jellyfin.getItems({ includeItemTypes: ['Movie'], recursive: true, limit: 1 })
+        );
+        const result = unwrap(await jellyfin.getRemoteImages(list.Items[0].Id, 'Primary'));
+
+        expect(Array.isArray(result.Images)).toBe(true);
+        if (result.Images.length === 0) return; // no provider reachable in this environment
+        const candidate = result.Images[0];
+        expect(typeof candidate.Url).toBe('string');
+        expect(typeof candidate.ProviderName).toBe('string');
+        expect(typeof candidate.CommunityRating).toBe('number');
+        // Width/Height are present on 10.11 but dropped on 12.0, even though the
+        // OpenAPI schema still declares them. Callers choosing on resolution must
+        // tolerate their absence.
+        expect(['number', 'undefined']).toContain(typeof candidate.Width);
+      });
+
+      it('replaces artwork from a URL and can remove it again', async () => {
+        const list = unwrap(
+          await jellyfin.getItems({ includeItemTypes: ['Movie'], recursive: true, limit: 1 })
+        );
+        const itemId = list.Items[0].Id;
+
+        const remote = unwrap(await jellyfin.getRemoteImages(itemId, 'Primary'));
+        if (!remote.Images?.length) return; // no provider reachable
+
+        // Pick the best candidate the way a caller fixing a bad cover would:
+        // by resolution where the server reports it, otherwise by rating.
+        const hasDimensions = remote.Images.some((i: any) => typeof i.Width === 'number');
+        const best = [...remote.Images].sort((a: any, b: any) =>
+          hasDimensions
+            ? (b.Width ?? 0) - (a.Width ?? 0)
+            : (b.CommunityRating ?? 0) - (a.CommunityRating ?? 0)
+        )[0];
+
+        await jellyfin.downloadRemoteImage(itemId, 'Primary', best.Url);
+        const after = unwrap(await jellyfin.getItemImages(itemId));
+        const primary = after.find((i: any) => i.ImageType === 'Primary');
+        expect(primary).toBeDefined();
+        // The item's own artwork always reports dimensions, whichever server.
+        expect(primary.Width).toBeGreaterThan(0);
+        if (hasDimensions) expect(primary.Width).toBe(best.Width);
+
+        await jellyfin.deleteItemImage(itemId, 'Primary');
+        const removed = unwrap(await jellyfin.getItemImages(itemId));
+        expect(removed.some((i: any) => i.ImageType === 'Primary')).toBe(false);
+
+        // Restore so reruns start from a known state.
+        await jellyfin.downloadRemoteImage(itemId, 'Primary', best.Url);
+      });
+    });
+
     describe('search', () => {
       it('finds a seeded movie by name', async () => {
         const result = unwrap(await jellyfin.search('Matrix'));


### PR DESCRIPTION
Built for agent use: *"this movie has no cover / a bad one, can you fix it?"*

The four steps an agent needs — find the item, judge the artwork, list candidates, apply one — are now all CLI commands.

```bash
tsarr jellyfin item list  --search "Pokemon" --type Movie --json --select Id,Name
tsarr jellyfin image list --id <itemId> --json          # no Primary row = no cover
tsarr jellyfin image remote --id <itemId> --type Primary --limit 10 --json
tsarr jellyfin image set   --id <itemId> --type Primary --url "<url>"
```

`image set --url` accepts **any reachable image URL**, not just provider candidates, so an agent can apply a cover it found anywhere.

## Real round trip, on the test bed

```
image list    → Primary 1500x2250
image remote  → TheMovieDb 2000x3000 rating 6.04  (higher res available)
image set     → applied
image list    → Primary 2000x3000 (847 KB)
image delete  → Primary gone
```

## New commands

| Action | Args | Purpose |
|---|---|---|
| `list` | `--id` | Artwork an item has, **with dimensions** — spots missing or poor covers |
| `remote` | `--id [--type] [--provider] [--all-languages] [--limit]` | Candidates with provider, language, rating |
| `providers` | `--id` | Which artwork providers apply |
| `set` | `--id --type --url` | Attach from a URL, replacing the existing image |
| `delete` | `--id --type [--index]` | Remove artwork (confirms) |

Only image *management* is wrapped. The ~30 `GET /Items/{id}/Images/...` variants serve raw JPEG/PNG bytes and have no useful CLI or SDK shape.

## A 10.11 vs 12.0 difference, caught by the dual-server test bed

**Jellyfin 12.0 omits `Width`/`Height` from `RemoteImageInfo`; 10.11 reports them** — same 129 candidates, same ratings, but no dimensions. The OpenAPI schema declares those fields on *both*, so the spec does not capture this.

```
stable 10.11.11  keys: ProviderName, Url, Height, Width, CommunityRating, VoteCount, Language, ...
next   12.0.0    keys: ProviderName, Url,                CommunityRating, VoteCount, Language, ...
```

It matters directly here: ranking candidates by resolution silently breaks on 12.0. Anything choosing a "best" cover must fall back to `CommunityRating`.

This is exactly what #242's second server was for — it surfaced on the first run of the new tests, and would otherwise have shipped as a subtle 12.0-only bug.

Handled by: documenting it in the client JSDoc, `docs/cli-commands.md` and the skill; and writing the tests to assert the tolerant behaviour rather than pinning one version.

## Agent enablement

`skills/tsarr/references/common-workflows.md` gains a **"Fix a missing or poor cover image"** section covering the lookup-don't-guess rule, how to rank candidates, the 12.0 caveat, applying an arbitrary URL, and a library-wide sweep for missing covers.

## Checks

| | before | after |
|---|---|---|
| Integration (per server) | 32 | **35** — 70 total |
| CLI smoke (per server) | 55 | **62** — 124 total |

`lint` ✅ · `typecheck` ✅ · `bun test` 409/409 offline ✅ · `build` ✅ · clean test bed cycle 70/70 + 124/124 on both servers ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)