### PR TITLE
fix(recording): stop clobbering local config, pin images, verify Jellyfin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ web_modules/
 
 # Local Tsarr CLI config (per-project secrets, like .env)
 .tsarr.json
+.tsarr.json.pre-recording
 
 # Local dev shim used when recording VHS demos against source
 .recording-bin/

--- a/docs/vhs/compose.recording.yml
+++ b/docs/vhs/compose.recording.yml
@@ -5,6 +5,10 @@
 #   vhs docs/vhs/workflow.tape
 #   bun run recording:down
 #
+# Images are pinned so a re-recording reproduces the same versions and output.
+# All four tags are verified to publish arm64. Bump them deliberately, then
+# re-record, rather than letting `latest` drift underneath the GIFs.
+#
 # Readarr is absent: upstream is archived and publishes no arm64 image.
 # Separate from docker/compose.test.yml on purpose: that one is for CI and must
 # stay fast, this one exists so the GIFs can be regenerated without hand setup.
@@ -21,21 +25,21 @@ x-arr: &arr
 services:
   radarr:
     <<: *arr
-    image: lscr.io/linuxserver/radarr:latest
+    image: lscr.io/linuxserver/radarr:6.3.0.10514-ls314
     container_name: tsarr-rec-radarr
     ports: ['127.0.0.1:17878:7878']
   sonarr:
     <<: *arr
-    image: lscr.io/linuxserver/sonarr:latest
+    image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls322
     container_name: tsarr-rec-sonarr
     ports: ['127.0.0.1:18989:8989']
   lidarr:
     <<: *arr
-    image: lscr.io/linuxserver/lidarr:latest
+    image: lscr.io/linuxserver/lidarr:3.1.0.4875-ls40
     container_name: tsarr-rec-lidarr
     ports: ['127.0.0.1:18686:8686']
   prowlarr:
     <<: *arr
-    image: lscr.io/linuxserver/prowlarr:latest
+    image: lscr.io/linuxserver/prowlarr:2.5.2.5491-ls157
     container_name: tsarr-rec-prowlarr
     ports: ['127.0.0.1:19696:9696']

--- a/scripts/recording.ts
+++ b/scripts/recording.ts
@@ -14,10 +14,19 @@
  * put `.recording-bin` first on PATH so `tsarr` runs from source.
  */
 
-import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 
 const COMPOSE_FILE = './docs/vhs/compose.recording.yml';
 const CONFIG_FILE = './.tsarr.json';
+const CONFIG_BACKUP = './.tsarr.json.pre-recording';
 const BIN_DIR = './.recording-bin';
 
 interface Service {
@@ -77,6 +86,31 @@ async function waitForApiKey(service: Service, timeoutMs = 240_000): Promise<str
   throw new Error(`${service.name} did not become ready within ${timeoutMs}ms`);
 }
 
+/** Returns Jellyfin credentials only if the server actually responds. */
+async function resolveJellyfin(): Promise<{ baseUrl: string; apiKey: string } | null> {
+  if (!existsSync('./.env.test')) return null;
+  const env = Object.fromEntries(
+    readFileSync('./.env.test', 'utf-8')
+      .split('\n')
+      .filter(line => line.includes('='))
+      .map(line => [line.slice(0, line.indexOf('=')), line.slice(line.indexOf('=') + 1)])
+  );
+  const baseUrl = env.JELLYFIN_BASE_URL;
+  const apiKey = env.JELLYFIN_API_KEY;
+  if (!baseUrl || !apiKey) return null;
+
+  try {
+    const response = await fetch(`${baseUrl}/System/Info`, {
+      headers: { Authorization: `MediaBrowser Token="${apiKey}"` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) return null;
+  } catch {
+    return null;
+  }
+  return { baseUrl, apiKey };
+}
+
 function writeShim() {
   mkdirSync(BIN_DIR, { recursive: true });
   const shim = `${BIN_DIR}/tsarr`;
@@ -97,21 +131,22 @@ async function up() {
     services[service.name] = { baseUrl: service.baseUrl, apiKey: await waitForApiKey(service) };
   }
 
-  // Reuse the Jellyfin the integration test bed already provisions, if it is up.
-  if (existsSync('./.env.test')) {
-    const env = Object.fromEntries(
-      require('node:fs')
-        .readFileSync('./.env.test', 'utf-8')
-        .split('\n')
-        .filter((l: string) => l.includes('='))
-        .map((l: string) => [l.slice(0, l.indexOf('=')), l.slice(l.indexOf('=') + 1)])
-    );
-    if (env.JELLYFIN_BASE_URL && env.JELLYFIN_API_KEY) {
-      services.jellyfin = { baseUrl: env.JELLYFIN_BASE_URL, apiKey: env.JELLYFIN_API_KEY };
-      console.log('✅ jellyfin picked up from the integration test bed');
-    }
+  // Reuse the Jellyfin the integration test bed provisions — but only if it is
+  // actually answering. `.env.test` outlives a stopped test bed, and a config
+  // pointing at a dead server would put an error row in the demo.
+  const jellyfin = await resolveJellyfin();
+  if (jellyfin) {
+    services.jellyfin = jellyfin;
+    console.log('✅ jellyfin picked up from the integration test bed');
   } else {
     console.log('ℹ️  Run `bun run testbed:up` first to include Jellyfin in the recording.');
+  }
+
+  // A contributor may have a real .tsarr.json pointing at their own homelab.
+  // Move it aside rather than overwriting it, and put it back on `down`.
+  if (existsSync(CONFIG_FILE) && !existsSync(CONFIG_BACKUP)) {
+    renameSync(CONFIG_FILE, CONFIG_BACKUP);
+    console.log(`💾 Moved your existing ${CONFIG_FILE} to ${CONFIG_BACKUP}`);
   }
 
   writeFileSync(CONFIG_FILE, `${JSON.stringify({ services }, null, 2)}\n`);
@@ -129,6 +164,11 @@ function down() {
   run(['docker', 'compose', '-f', COMPOSE_FILE, 'down', '-v']);
   rmSync(CONFIG_FILE, { force: true });
   rmSync(BIN_DIR, { recursive: true, force: true });
+
+  if (existsSync(CONFIG_BACKUP)) {
+    renameSync(CONFIG_BACKUP, CONFIG_FILE);
+    console.log(`♻️  Restored your original ${CONFIG_FILE}`);
+  }
   console.log('✅ Recording environment removed');
 }
 


### PR DESCRIPTION
Addresses the three review comments on #244 — which I merged before reading. My mistake; all three were valid, and the first is data loss.

## 1. `recording:up` destroyed a developer's local config (Major)

`recording:up` overwrote an existing `.tsarr.json`, and `recording:down` then deleted it. A contributor with a real config pointing at their own homelab would lose it **silently**.

Now moved aside and restored. Verified over a full cycle:

```
BEFORE   {"services":{"radarr":{"baseUrl":"http://my-homelab:7878","apiKey":"MY-REAL-KEY"}}}
up    →  💾 Moved your existing ./.tsarr.json to ./.tsarr.json.pre-recording
         (during recording, .tsarr.json holds radarr, sonarr, lidarr, prowlarr)
down  →  ♻️  Restored your original ./.tsarr.json
AFTER    {"services":{"radarr":{"baseUrl":"http://my-homelab:7878","apiKey":"MY-REAL-KEY"}}}
```

Byte-identical.

## 2. Jellyfin was trusted without checking it was up

Credentials came from `.env.test`, which outlives a stopped test bed — so a demo could be recorded against a dead server and show an error row in the `doctor` output.

`resolveJellyfin()` now probes `/System/Info` first. Verified with a stale `.env.test` and nothing listening:

```
stale .env.test present, no Jellyfin running
generated config: radarr, sonarr, lidarr, prowlarr
✅ correctly omitted
```

## 3. Mutable `latest` tags

Re-recording could silently pull different versions than the committed GIFs show. Pinned:

| | |
|---|---|
| radarr | `6.3.0.10514-ls314` |
| sonarr | `4.0.19.2979-ls322` |
| lidarr | `3.1.0.4875-ls40` |
| prowlarr | `2.5.2.5491-ls157` |

All verified to publish arm64. Three match the versions in the current recording exactly; Sonarr has moved on since I recorded, and I'd rather pin the tag than claim otherwise.

## Checks

`lint` ✅ · `typecheck` ✅ · `bun test` 339/339 ✅ · both failure modes reproduced and confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)